### PR TITLE
Sc greens functions

### DIFF
--- a/doc/routes/greens.rst
+++ b/doc/routes/greens.rst
@@ -1,0 +1,83 @@
+GET /greens
+^^^^^^^^^^^^^^^^
+
+.. note::
+
+    Some parts of this route require an advanced server setup. Please view the
+    :doc:`../advanced_server_configuration` for details. The parts that don't
+    will keep working even with a normal configuration.
+
+Description
+    Returns Instaseis Greens's function, that is seimograms for contraction with the
+    decomposition of the Momenttensor as in Minson & Dreger (2008). Several convenience
+    function of the ``/seismograms`` route are replicated here to make it suitable to be
+    queried by any program able to use HTTP
+
+    Minson, Sarah E., and Douglas S. Dreger. 2008. “Stable Inversions for Complete Moment
+    Tensors.” Geophysical Journal International 174 (2): 585–592.
+    doi:10.1111/j.1365-246X.2008.03797.x.
+
+Content-Type
+    * ``application/zip`` (if zipped SAC data is requested)
+    * ``application/octet-stream`` (if MiniSEED data is requested)
+
+Filetype
+    Returns a ZIP archive with SAC files or MiniSEED files encoded with
+    encoding format 4 (IEEE floating point).
+
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| Parameter                   | Type     | Required | Default Value               | Description                                                                          |
++=============================+==========+==========+=============================+======================================================================================+
+| **Source/Receiver Parameters**                                                                                                                                         |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``sourcedepthinmeters``     | Float    | True     |                             | The source depth in meters.                                                          |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``sourcedistanceindegree``  | Float    | True     |                             | The epicentral disctance of source - receiver in degrees (computed on the surface    |
+|                             |          |          |                             | of a sphere).                                                                        |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| **Output parameters**                                                                                                                                                  |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``format``                  | String   | False    | saczip                      | Specify output file to be either MiniSEED or a ZIP archive of SAC files, either      |
+|                             |          |          |                             | ``miniseed`` or ``saczip``.                                                          |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``label``                   | String   | False    |                             | Specify a label to be included in file names and HTTP file name suggestions.         |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``units``                   | String   | False    | displacement                | Specify either ``displacement``, ``velocity`` or ``acceleration`` for the synthetics.|
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``dt``                      | Float    | False    |                             | If given, seismograms will be resampled to the desired sample spacing.               |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``kernelwidth``             | Integer  | False    | 12                          | Specify the width of the sinc kernel used for resampling to requested sample         |
+|                             |          |          |                             | interval in terms of the original sampling interval.                                 |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| **Time Parameters**                                                                                                                                                    |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``origintime``              | Datetime | False    | 1970-01-01T00:00:00.000000Z | Specify the source origin time. This must be specified as an                         |
+|                             |          |          |                             | absolute date and time. This time coincides with the peak of the                     |
+|                             |          |          |                             | source time function.                                                                |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``starttime``               | Datetime | False    |                             | Specifies the desired start time for the synthetic trace(s). This may be specified   |
+|                             |          |          |                             | as either:                                                                           |
+|                             |          |          |                             |                                                                                      |
+|                             |          |          |                             | * an absolute date and time                                                          |
+|                             |          |          |                             | * a phase-relative offset                                                            |
+|                             |          |          |                             | * an offset from origin time in seconds                                              |
+|                             |          |          |                             |                                                                                      |
+|                             |          |          |                             | If the value is recognized as a date and time, it is interpreted as an absolute time.|
+|                             |          |          |                             | If the value is in the form ``phase[+-]offset`` it is interpreted as a               |
+|                             |          |          |                             | phase-relative time, for example ``P-10`` (meaning P-wave arrival time minus 10      |
+|                             |          |          |                             | seconds). If the value is a numerical value it is interpreted as an offset, in       |
+|                             |          |          |                             | seconds, from the origin time.                                                       |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``endtime``                 | Datetime | False    |                             | Specifies the desired end time for the synthetic trace(s). This may be specified     |
+|                             |          |          |                             | as either:                                                                           |
+|                             |          |          |                             |                                                                                      |
+|                             |          |          |                             | * an absolute date and time                                                          |
+|                             |          |          |                             | * a phase-relative offset                                                            |
+|                             |          |          |                             | * an offset (duration) from start time in seconds                                    |
+|                             |          |          |                             |                                                                                      |
+|                             |          |          |                             | If the value is recognized as a date and time, it is interpreted as an absolute time.|
+|                             |          |          |                             | If the value is in the form ``phase[+-]offset`` it is interpreted as a               |
+|                             |          |          |                             | phase-relative time, for example ``P-10`` (meaning P-wave arrival time minus 10      |
+|                             |          |          |                             | seconds). If the value is a numerical value it is interpreted as an offset, in       |
+|                             |          |          |                             | seconds, from the start time.                                                        |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+

--- a/doc/routes/greens.rst
+++ b/doc/routes/greens.rst
@@ -11,11 +11,14 @@ Description
     Returns Instaseis Greens's function, that is seimograms for contraction with the
     decomposition of the Momenttensor as in Minson & Dreger (2008). Several convenience
     function of the ``/seismograms`` route are replicated here to make it suitable to be
-    queried by any program able to use HTTP
+    queried by any program able to use HTTP.
 
-    Minson, Sarah E., and Douglas S. Dreger. 2008. “Stable Inversions for Complete Moment
-    Tensors.” Geophysical Journal International 174 (2): 585–592.
-    doi:10.1111/j.1365-246X.2008.03797.x.
+    .. list-table::
+
+        * - | Minson, Sarah E., and Douglas S. Dreger (2008)
+            | **Stable Inversions for Complete Moment Tensors.**
+            | *Geophysical Journal International* 174 (2): 585–592.
+            | http://dx.doi.org/10.1111/j.1365-246X.2008.03797.x
 
 Content-Type
     * ``application/zip`` (if zipped SAC data is requested)

--- a/doc/routes/greens_function.rst
+++ b/doc/routes/greens_function.rst
@@ -1,5 +1,5 @@
-GET /greens
-^^^^^^^^^^^^^^^^
+GET /greens_function
+^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 

--- a/doc/server.rst
+++ b/doc/server.rst
@@ -179,7 +179,7 @@ REST-like API Documentation
 
 If you wish to use the Instaseis Server without the Python client this
 documentation might be helpful. The Instaseis server offers a REST-like API
-with currently seven endpoints only supporting GET.
+with currently eight endpoints only supporting GET.
 
 .. toctree::
 

--- a/doc/server.rst
+++ b/doc/server.rst
@@ -190,3 +190,4 @@ with currently seven endpoints only supporting GET.
     routes/ttimes
     routes/seismograms_raw
     routes/seismograms
+    routes/greens

--- a/doc/server.rst
+++ b/doc/server.rst
@@ -190,4 +190,4 @@ with currently eight endpoints only supporting GET.
     routes/ttimes
     routes/seismograms_raw
     routes/seismograms
-    routes/greens
+    routes/greens_function

--- a/instaseis/base_instaseis_db.py
+++ b/instaseis/base_instaseis_db.py
@@ -145,7 +145,7 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
                 dt_out = self.info.dt
             else:
                 dt_out = dt
-            components = data.keys()
+            components = list(data.keys())
             components.remove('mu')
             return self._convert_to_stream(
                 receiver=receiver, components=components,

--- a/instaseis/base_instaseis_db.py
+++ b/instaseis/base_instaseis_db.py
@@ -34,18 +34,23 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
     """
     Base class for all Instaseis database classes defining the user interface.
     """
-    def get_greens_seiscomp(self, epicentral_distance_in_degree,
+    def get_greens_function(self, epicentral_distance_in_degree,
                             source_depth_in_m, origin_time=UTCDateTime(0),
                             kind='displacement', return_obspy_stream=True,
-                            dt=None, kernelwidth=12):
+                            dt=None, kernelwidth=12, definition='seiscomp'):
         """
-        Extract Green's function from the Green's function database in the
-        format assumed by Seiscomp, i.e. the components TSS, ZSS, RSS, TDS,
-        ZDS, RDS, ZDD, RDD, ZEP, REP as defined in
+        Extract Green's function from the Green's function database.
 
-        Minson, Sarah E., and Douglas S. Dreger. 2008. “Stable Inversions for
-        Complete Moment Tensors.” Geophysical Journal International 174 (2):
-        585–592.  doi:10.1111/j.1365-246X.2008.03797.x.
+        Currently only one definition is implemented: the one assumed by
+        Seiscomp, i.e. the components ``TSS``, ``ZSS``, ``RSS``, ``TDS``,
+        ``ZDS``, ``RDS``, ``ZDD``, ``RDD``, ``ZEP``, ``REP`` as defined in
+
+        .. list-table::
+
+            * - | Minson, Sarah E., and Douglas S. Dreger (2008)
+                | **Stable Inversions for Complete Moment Tensors.**
+                | *Geophysical Journal International* 174 (2): 585–592.
+                | http://dx.doi.org/10.1111/j.1365-246X.2008.03797.x
 
         :param epicentral_distance_in_degree: The epicentral distance in
             degree.
@@ -56,19 +61,26 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
         :type origin_time: :class:`obspy.core.utcdatetime.UTCDateTime`
         :param kind: The desired units of the seismogram:
             ``"displacement"``, ``"velocity"``, or ``"acceleration"``.
-        :type kind: str, optional
+        :type kind: str
         :param dt: Desired sampling rate of the Green's functions. Resampling
             is done using a Lanczos kernel.
-        :type dt: float, optional
+        :type dt: float
         :param kernelwidth: The width of the sinc kernel used for resampling in
             terms of the original sampling interval. Best choose something
             between 10 and 20.
-        :type kernelwidth: int, optional
+        :type kernelwidth: int
+        :param definition: The desired Green's function definition.
+        :type definition: str
 
         :returns: Multi component seismograms.
         :rtype: A :class:`obspy.core.stream.Stream` object or a dictionary
             with NumPy arrays as values.
         """
+        # Currently only the seiscomp definition is implemented. Other
+        # implementations will require a refactoring of this method.
+        if definition.lower() != "seiscomp":
+            raise NotImplementedError
+
         self._get_greens_seiscomp_sanity_checks(epicentral_distance_in_degree,
                                                 source_depth_in_m, kind)
 

--- a/instaseis/base_instaseis_db.py
+++ b/instaseis/base_instaseis_db.py
@@ -34,7 +34,7 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
     """
     Base class for all Instaseis database classes defining the user interface.
     """
-    def get_greens_seiscomp(self, epicentral_distance_degree,
+    def get_greens_seiscomp(self, epicentral_distance_in_degree,
                             source_depth_in_m, origin_time=UTCDateTime(0),
                             kind='displacement', return_obspy_stream=True,
                             dt=None, kernelwidth=12):
@@ -47,8 +47,9 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
         Complete Moment Tensors.” Geophysical Journal International 174 (2):
         585–592.  doi:10.1111/j.1365-246X.2008.03797.x.
 
-        :param epicentral_distance_degree: The epicentral distance in degree.
-        :type epicentral_distance_degree: float
+        :param epicentral_distance_in_degree: The epicentral distance in
+            degree.
+        :type epicentral_distance_in_degree: float
         :param source_depth_in_m: The source depth in m below the surface.
         :type source_depth_in_m: float
         :param origin_time: Origin time of the source.
@@ -68,11 +69,11 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
         :rtype: A :class:`obspy.core.stream.Stream` object or a dictionary
             with NumPy arrays as values.
         """
-        self._get_greens_seiscomp_sanity_checks(epicentral_distance_degree,
+        self._get_greens_seiscomp_sanity_checks(epicentral_distance_in_degree,
                                                 source_depth_in_m, kind)
 
         src_latitude, src_longitude = 90., 0.
-        rec_latitude, rec_longitude = 90. - epicentral_distance_degree, 0.
+        rec_latitude, rec_longitude = 90. - epicentral_distance_in_degree, 0.
 
         # sources according to https://github.com/krischer/instaseis/issues/8
         # transformed to r, theta, phi

--- a/instaseis/base_instaseis_db.py
+++ b/instaseis/base_instaseis_db.py
@@ -35,8 +35,9 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
     Base class for all Instaseis database classes defining the user interface.
     """
     def get_greens_seiscomp(self, epicentral_distance_degree,
-                            source_depth_in_m, kind='displacement',
-                            return_obspy_stream=True, dt=None, kernelwidth=12):
+                            source_depth_in_m, origin_time=UTCDateTime(0),
+                            kind='displacement', return_obspy_stream=True,
+                            dt=None, kernelwidth=12):
         """
         Extract Green's function from the Green's function database in the
         format assumed by Seiscomp, i.e. the components TSS, ZSS, RSS, TDS,
@@ -50,6 +51,8 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
         :type epicentral_distance_degree: float
         :param source_depth_in_m: The source depth in m below the surface.
         :type source_depth_in_m: float
+        :param origin_time: Origin time of the source.
+        :type origin_time: :class:`obspy.core.utcdatetime.UTCDateTime`
         :param kind: The desired units of the seismogram:
             ``"displacement"``, ``"velocity"``, or ``"acceleration"``.
         :type kind: str, optional
@@ -86,17 +89,17 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
         #  2.0  -1.0  -1.0    0      0      0      cl
 
         m1 = Source(src_latitude, src_longitude, source_depth_in_m,
-                    m_tp=-1.0)
+                    m_tp=-1.0, origin_time=origin_time)
         m2 = Source(src_latitude, src_longitude, source_depth_in_m,
-                    m_tt=1.0, m_pp=-1.0)
+                    m_tt=1.0, m_pp=-1.0, origin_time=origin_time)
         m3 = Source(src_latitude, src_longitude, source_depth_in_m,
-                    m_rp=-1.0)
+                    m_rp=-1.0, origin_time=origin_time)
         m4 = Source(src_latitude, src_longitude, source_depth_in_m,
-                    m_rt=1.0)
+                    m_rt=1.0, origin_time=origin_time)
         m6 = Source(src_latitude, src_longitude, source_depth_in_m,
-                    m_rr=1.0, m_tt=1.0, m_pp=1.0)
+                    m_rr=1.0, m_tt=1.0, m_pp=1.0, origin_time=origin_time)
         cl = Source(src_latitude, src_longitude, source_depth_in_m,
-                    m_rr=2.0, m_tt=-1.0, m_pp=-1.0)
+                    m_rr=2.0, m_tt=-1.0, m_pp=-1.0, origin_time=origin_time)
 
         receiver = Receiver(rec_latitude, rec_longitude)
 

--- a/instaseis/server/app.py
+++ b/instaseis/server/app.py
@@ -24,7 +24,7 @@ from .routes.index import IndexHandler
 from .routes.info import InfoHandler
 from .routes.seismograms import SeismogramsHandler
 from .routes.seismograms_raw import RawSeismogramsHandler
-from .routes.greens import GreensHandler
+from .routes.greens import GreensFunctionHandler
 
 
 def get_application():
@@ -37,7 +37,7 @@ def get_application():
     return tornado.web.Application([
         (r"/seismograms", SeismogramsHandler),
         (r"/seismograms_raw", RawSeismogramsHandler),
-        (r"/greens", GreensHandler),
+        (r"/greens_function", GreensFunctionHandler),
         (r"/info", InfoHandler),
         (r"/", IndexHandler),
         (r"/coordinates", CoordinatesHandler),

--- a/instaseis/server/app.py
+++ b/instaseis/server/app.py
@@ -24,6 +24,7 @@ from .routes.index import IndexHandler
 from .routes.info import InfoHandler
 from .routes.seismograms import SeismogramsHandler
 from .routes.seismograms_raw import RawSeismogramsHandler
+from .routes.greens import GreensHandler
 
 
 def get_application():
@@ -36,6 +37,7 @@ def get_application():
     return tornado.web.Application([
         (r"/seismograms", SeismogramsHandler),
         (r"/seismograms_raw", RawSeismogramsHandler),
+        (r"/greens", GreensHandler),
         (r"/info", InfoHandler),
         (r"/", IndexHandler),
         (r"/coordinates", CoordinatesHandler),

--- a/instaseis/server/instaseis_request.py
+++ b/instaseis/server/instaseis_request.py
@@ -12,6 +12,7 @@ Base Instaseis Request handler currently only settings default headers.
 from abc import abstractmethod
 import obspy
 import tornado
+from ..base_instaseis_db import _get_seismogram_times
 
 from .. import __version__
 
@@ -24,10 +25,18 @@ class InstaseisRequestHandler(tornado.web.RequestHandler):
 
 class InstaseisTimeSeriesHandler(InstaseisRequestHandler):
     arguments = None
+    connection_closed = False
 
     def __init__(self, *args, **kwargs):
-        self.__connection_closed = False
-        InstaseisRequestHandler.__init__(self, *args, **kwargs)
+        super(InstaseisTimeSeriesHandler, self).__init__(*args, **kwargs)
+
+    def on_connection_close(self):
+        """
+        Called when the client cancels the connection. Then the loop
+        requesting seismograms will stop.
+        """
+        InstaseisRequestHandler.on_connection_close(self)
+        self.__connection_closed = True
 
     def parse_arguments(self):
         # Make sure that no additional arguments are passed.
@@ -90,3 +99,152 @@ class InstaseisTimeSeriesHandler(InstaseisRequestHandler):
     @abstractmethod
     def validate_parameters(self, args):
         pass
+
+    def parse_time_settings(self, args):
+        """
+        Attempt to figure out the time settings.
+
+        This is pretty messy unfortunately. After this method has been
+        called, args.origintime will always be set to an absolute time.
+
+        args.starttime and args.endtime will either be set to absolute times
+        or dictionaries describing phase relative offsets.
+
+        Returns the minium possible start- and the maximum possible endtime.
+        """
+        if args.origintime is None:
+            args.origintime = obspy.UTCDateTime(0)
+
+        # The origin time will be always set. If the starttime is not set,
+        # set it to the origin time.
+        if args.starttime is None:
+            args.starttime = args.origintime
+
+        # Now it becomes a bit ugly. If the starttime is a float, treat it
+        # relative to the origin time.
+        if isinstance(args.starttime, float):
+            args.starttime = args.origintime + args.starttime
+
+        # Now deal with the endtime.
+        if isinstance(args.endtime, float):
+            # If the start time is already known as an absolute time,
+            # just add it.
+            if isinstance(args.starttime, obspy.UTCDateTime):
+                args.endtime = args.starttime + args.endtime
+            # Otherwise the start time has to be a phase relative time and
+            # is dealt with later.
+            else:
+                assert isinstance(args.starttime, obspy.core.AttribDict)
+
+        # Figure out the maximum temporal range of the seismograms.
+        ti = _get_seismogram_times(
+            info=self.application.db.info, origin_time=args.origintime,
+            dt=args.dt, kernelwidth=args.kernelwidth,
+            remove_source_shift=False, reconvolve_stf=False)
+
+        # If the endtime is not set, do it here.
+        if args.endtime is None:
+            args.endtime = ti["endtime"]
+
+        # Do a couple of sanity checks here.
+        if isinstance(args.starttime, obspy.UTCDateTime):
+            # The desired seismogram start time must be before the end time of
+            # the seismograms.
+            if args.starttime >= ti["endtime"]:
+                msg = ("The `starttime` must be before the seismogram ends.")
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+            # Arbitrary limit: The starttime can be at max one hour before the
+            # origin time.
+            if args.starttime < (ti["starttime"] - 3600):
+                msg = ("The seismogram can start at the maximum one hour "
+                       "before the origin time.")
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        if isinstance(args.endtime, obspy.UTCDateTime):
+            # The endtime must be within the seismogram window
+            if not (ti["starttime"] <= args.endtime <= ti["endtime"]):
+                msg = ("The end time of the seismograms lies outside the "
+                       "allowed range.")
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        return ti["starttime"], ti["endtime"]
+
+    def set_headers(self, default_label, args):
+        if args.format == "miniseed":
+            content_type = "application/octet-stream"
+        elif args.format == "saczip":
+            content_type = "application/zip"
+        self.set_header("Content-Type", content_type)
+
+        FILE_ENDINGS_MAP = {
+            "miniseed": "mseed",
+            "saczip": "zip"}
+
+        if args.label:
+            label = args.label
+        else:
+            label = default_label
+
+        filename = "%s_%s.%s" % (
+            label,
+            str(obspy.UTCDateTime()).replace(":", "_"),
+            FILE_ENDINGS_MAP[args.format])
+
+        self.set_header("Content-Disposition",
+                        "attachment; filename=%s" % filename)
+
+    def get_ttime(self, source, receiver, phase):
+        if self.application.travel_time_callback is None:
+            msg = "Server does not support travel time calculations."
+            raise tornado.web.HTTPError(
+                404, log_message=msg, reason=msg)
+        try:
+            tt = self.application.travel_time_callback(
+                sourcelatitude=source.latitude,
+                sourcelongitude=source.longitude,
+                sourcedepthinmeters=source.depth_in_m,
+                receiverlatitude=receiver.latitude,
+                receiverlongitude=receiver.longitude,
+                receiverdepthinmeters=receiver.depth_in_m,
+                phase_name=phase)
+        except ValueError as e:
+            err_msg = str(e)
+            if err_msg.lower().startswith("invalid phase name"):
+                msg = "Invalid phase name: %s" % phase
+            else:
+                msg = "Failed to calculate travel time due to: %s" % err_msg
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+        return tt
+
+    def validate_geometry(self, source, receiver):
+        """
+        Validate the source-receiver geometry.
+        """
+        info = self.application.db.info
+
+        # XXX: Will have to be changed once we have a database recorded for
+        # example on the ocean bottom.
+        if info.is_reciprocal:
+            # Receiver must be at the surface.
+            if receiver.depth_in_m is not None:
+                if receiver.depth_in_m != 0.0:
+                    msg = "Receiver must be at the surface for reciprocal " \
+                          "databases."
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+            # Source depth must be within the allowed range.
+            if not ((info.planet_radius - info.max_radius) <=
+                    source.depth_in_m <=
+                    (info.planet_radius - info.min_radius)):
+                msg = ("Source depth must be within the database range: %.1f "
+                       "- %.1f meters.") % (
+                        info.planet_radius - info.max_radius,
+                        info.planet_radius - info.min_radius)
+                raise tornado.web.HTTPError(400, log_message=msg,
+                                            reason=msg)
+        else:
+            # The source depth must coincide with the one in the database.
+            if source.depth_in_m != info.source_depth * 1000:
+                    msg = "Source depth must be: %.1f km" % info.source_depth
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)

--- a/instaseis/server/instaseis_request.py
+++ b/instaseis/server/instaseis_request.py
@@ -9,6 +9,8 @@ Base Instaseis Request handler currently only settings default headers.
     GNU Lesser General Public License, Version 3 [non-commercial/academic use]
     (http://www.gnu.org/copyleft/lgpl.html)
 """
+from abc import abstractmethod
+import obspy
 import tornado
 
 from .. import __version__
@@ -18,3 +20,73 @@ class InstaseisRequestHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Server", "InstaseisServer/%s" % __version__)
+
+
+class InstaseisTimeSeriesHandler(InstaseisRequestHandler):
+    arguments = None
+
+    def __init__(self, *args, **kwargs):
+        self.__connection_closed = False
+        InstaseisRequestHandler.__init__(self, *args, **kwargs)
+
+    def parse_arguments(self):
+        # Make sure that no additional arguments are passed.
+        unknown_arguments = set(self.request.arguments.keys()).difference(set(
+            self.arguments.keys()))
+        if unknown_arguments:
+            msg = "The following unknown parameters have been passed: %s" % (
+                ", ".join("'%s'" % _i for _i in sorted(unknown_arguments)))
+            raise tornado.web.HTTPError(400, log_message=msg,
+                                        reason=msg)
+
+        # Check for duplicates.
+        duplicates = []
+        for key, value in self.request.arguments.items():
+            if len(value) == 1:
+                continue
+            else:
+                duplicates.append(key)
+        if duplicates:
+            msg = "Duplicate parameters: %s" % (
+                ", ".join("'%s'" % _i for _i in sorted(duplicates)))
+            raise tornado.web.HTTPError(400, log_message=msg,
+                                        reason=msg)
+
+        args = obspy.core.AttribDict()
+        for name, properties in self.arguments.items():
+            if "required" in properties:
+                try:
+                    value = self.get_argument(name)
+                except:
+                    msg = "Required parameter '%s' not given." % name
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+            else:
+                if "default" in properties:
+                    default = properties["default"]
+                else:
+                    default = None
+                value = self.get_argument(name, default=default)
+            if value is not None:
+                try:
+                    value = properties["type"](value)
+                except:
+                    if "format" in properties:
+                        msg = "Parameter '%s' must be formatted as: '%s'" % (
+                            name, properties["format"])
+                    else:
+                        msg = ("Parameter '%s' could not be converted to "
+                               "'%s'.") % (
+                            name, str(properties["type"].__name__))
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+            setattr(args, name, value)
+
+        # Validate some of them right here.
+        self.validate_parameters(args)
+
+        return args
+
+    @abstractmethod
+    def validate_parameters(self, args):
+        pass

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -17,7 +17,6 @@ import tornado.gen
 import tornado.web
 
 from ... import Source, Receiver
-from ...base_instaseis_db import _get_seismogram_times
 from ..util import run_async, IOQueue, _validtimesetting
 from ..instaseis_request import InstaseisTimeSeriesHandler
 from ...helpers import geocentric_to_wgs84_latitude
@@ -142,16 +141,7 @@ class GreensHandler(InstaseisTimeSeriesHandler):
     }
 
     def __init__(self, *args, **kwargs):
-        self.__connection_closed = False
-        InstaseisTimeSeriesHandler.__init__(self, *args, **kwargs)
-
-    def on_connection_close(self):
-        """
-        Called when the client cancels the connection. Then the loop
-        requesting seismograms will stop.
-        """
-        InstaseisTimeSeriesHandler.on_connection_close(self)
-        self.__connection_closed = True
+        super(InstaseisTimeSeriesHandler, self).__init__(*args, **kwargs)
 
     def validate_parameters(self, args):
         """
@@ -217,155 +207,6 @@ class GreensHandler(InstaseisTimeSeriesHandler):
                    "20.")
             raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
 
-    def parse_time_settings(self, args):
-        """
-        Attempt to figure out the time settings.
-
-        This is pretty messy unfortunately. After this method has been
-        called, args.origintime will always be set to an absolute time.
-
-        args.starttime and args.endtime will either be set to absolute times
-        or dictionaries describing phase relative offsets.
-
-        Returns the minium possible start- and the maximum possible endtime.
-        """
-        if args.origintime is None:
-            args.origintime = obspy.UTCDateTime(0)
-
-        # The origin time will be always set. If the starttime is not set,
-        # set it to the origin time.
-        if args.starttime is None:
-            args.starttime = args.origintime
-
-        # Now it becomes a bit ugly. If the starttime is a float, treat it
-        # relative to the origin time.
-        if isinstance(args.starttime, float):
-            args.starttime = args.origintime + args.starttime
-
-        # Now deal with the endtime.
-        if isinstance(args.endtime, float):
-            # If the start time is already known as an absolute time,
-            # just add it.
-            if isinstance(args.starttime, obspy.UTCDateTime):
-                args.endtime = args.starttime + args.endtime
-            # Otherwise the start time has to be a phase relative time and
-            # is dealt with later.
-            else:
-                assert isinstance(args.starttime, obspy.core.AttribDict)
-
-        # Figure out the maximum temporal range of the seismograms.
-        ti = _get_seismogram_times(
-            info=self.application.db.info, origin_time=args.origintime,
-            dt=args.dt, kernelwidth=args.kernelwidth,
-            remove_source_shift=False, reconvolve_stf=False)
-
-        # If the endtime is not set, do it here.
-        if args.endtime is None:
-            args.endtime = ti["endtime"]
-
-        # Do a couple of sanity checks here.
-        if isinstance(args.starttime, obspy.UTCDateTime):
-            # The desired seismogram start time must be before the end time of
-            # the seismograms.
-            if args.starttime >= ti["endtime"]:
-                msg = ("The `starttime` must be before the seismogram ends.")
-                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-            # Arbitrary limit: The starttime can be at max one hour before the
-            # origin time.
-            if args.starttime < (ti["starttime"] - 3600):
-                msg = ("The seismogram can start at the maximum one hour "
-                       "before the origin time.")
-                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-
-        if isinstance(args.endtime, obspy.UTCDateTime):
-            # The endtime must be within the seismogram window
-            if not (ti["starttime"] <= args.endtime <= ti["endtime"]):
-                msg = ("The end time of the seismograms lies outside the "
-                       "allowed range.")
-                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-
-        return ti["starttime"], ti["endtime"]
-
-    def set_headers(self, args):
-        if args.format == "miniseed":
-            content_type = "application/octet-stream"
-        elif args.format == "saczip":
-            content_type = "application/zip"
-        self.set_header("Content-Type", content_type)
-
-        FILE_ENDINGS_MAP = {
-            "miniseed": "mseed",
-            "saczip": "zip"}
-
-        if args.label:
-            label = args.label
-        else:
-            label = "instaseis_greens"
-
-        filename = "%s_%s.%s" % (
-            label,
-            str(obspy.UTCDateTime()).replace(":", "_"),
-            FILE_ENDINGS_MAP[args.format])
-
-        self.set_header("Content-Disposition",
-                        "attachment; filename=%s" % filename)
-
-    def get_ttime(self, source, receiver, phase):
-        if self.application.travel_time_callback is None:
-            msg = "Server does not support travel time calculations."
-            raise tornado.web.HTTPError(
-                404, log_message=msg, reason=msg)
-        try:
-            tt = self.application.travel_time_callback(
-                sourcelatitude=source.latitude,
-                sourcelongitude=source.longitude,
-                sourcedepthinmeters=source.depth_in_m,
-                receiverlatitude=receiver.latitude,
-                receiverlongitude=receiver.longitude,
-                receiverdepthinmeters=receiver.depth_in_m,
-                phase_name=phase)
-        except ValueError as e:
-            err_msg = str(e)
-            if err_msg.lower().startswith("invalid phase name"):
-                msg = "Invalid phase name: %s" % phase
-            else:
-                msg = "Failed to calculate travel time due to: %s" % err_msg
-            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-        return tt
-
-    def validate_geometry(self, source, receiver):
-        """
-        Validate the source-receiver geometry.
-        """
-        info = self.application.db.info
-
-        # XXX: Will have to be changed once we have a database recorded for
-        # example on the ocean bottom.
-        if info.is_reciprocal:
-            # Receiver must be at the surface.
-            if receiver.depth_in_m is not None:
-                if receiver.depth_in_m != 0.0:
-                    msg = "Receiver must be at the surface for reciprocal " \
-                          "databases."
-                    raise tornado.web.HTTPError(400, log_message=msg,
-                                                reason=msg)
-            # Source depth must be within the allowed range.
-            if not ((info.planet_radius - info.max_radius) <=
-                    source.depth_in_m <=
-                    (info.planet_radius - info.min_radius)):
-                msg = ("Source depth must be within the database range: %.1f "
-                       "- %.1f meters.") % (
-                        info.planet_radius - info.max_radius,
-                        info.planet_radius - info.min_radius)
-                raise tornado.web.HTTPError(400, log_message=msg,
-                                            reason=msg)
-        else:
-            # The source depth must coincide with the one in the database.
-            if source.depth_in_m != info.source_depth * 1000:
-                    msg = "Source depth must be: %.1f km" % info.source_depth
-                    raise tornado.web.HTTPError(400, log_message=msg,
-                                                reason=msg)
-
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
@@ -374,7 +215,7 @@ class GreensHandler(InstaseisTimeSeriesHandler):
         args = self.parse_arguments()
 
         min_starttime, max_endtime = self.parse_time_settings(args)
-        self.set_headers(args)
+        self.set_headers("instaseis_greens", args)
 
         # generating source and receiver as in the get_greens routine of the
         # base_instaseis class
@@ -397,12 +238,12 @@ class GreensHandler(InstaseisTimeSeriesHandler):
         # XXX: only one reqest here, keeping the loop structure to enable the
         # 'count' test as in the seismograms route
         for receiver in receivers:
-            # Check if the connection is still open. The __connection_closed
+            # Check if the connection is still open. The connection_closed
             # flag is set by the on_connection_close() method. This is
             # pretty manual right now. Maybe there is a better way? This
             # enables to server to stop serving if the connection has been
             # cancelled on the client side.
-            if self.__connection_closed:
+            if self.connection_closed:
                 self.flush()
                 self.finish()
                 return

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -90,7 +90,7 @@ def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
             binary_data = fh.read()
         callback(binary_data)
     # Write a number of SAC files into an archive.
-    elif format == "sac":
+    elif format == "saczip":
         byte_strings = []
         for tr in st:
             # Write SAC headers.

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -164,9 +164,13 @@ class GreensFunctionHandler(InstaseisTimeSeriesHandler):
                 not 0.0 <= args.sourcedistanceindegrees <= 180.0:
             msg = ("Epicentral distance should be in [0, 180].")
             raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        min_depth = info.planet_radius - info.max_radius
+        max_depth = info.planet_radius - info.min_radius
         if args.sourcedepthinmeters is not None and \
-                not 0.0 <= args.sourcedepthinmeters <= info.planet_radius:
-            msg = ("Source depth should be in [0, planet radius].")
+                not min_depth <= args.sourcedepthinmeters <= max_depth:
+            msg = ("Source depth should be in [%.1f, %.1f]." % (
+                   min_depth, max_depth))
             raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
 
     @tornado.web.asynchronous

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:copyright:
+    Martin van Driel (vandriel@erdw.ethz.ch), 2015
+    Lion Krischer (krischer@geophysik.uni-muenchen.de), 2015
+:license:
+    GNU Lesser General Public License, Version 3 [non-commercial/academic use]
+    (http://www.gnu.org/copyleft/lgpl.html)
+"""
+import io
+import re
+import zipfile
+
+import numpy as np
+import obspy
+import tornado.gen
+import tornado.web
+
+from ... import Source, Receiver
+from ...base_instaseis_db import _get_seismogram_times
+from ..util import run_async
+from ..instaseis_request import InstaseisRequestHandler
+from ...helpers import geocentric_to_wgs84_latitude
+
+# Valid phase offset pattern including capture groups.
+PHASE_OFFSET_PATTERN = re.compile(r"(^[A-Za-z0-9^]+)([\+-])([\deE\.\-\+]+$)")
+
+
+@run_async
+def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
+                kernelwidth, origintime, starttime, endtime, format, label,
+                callback):
+    """
+    Extract a seismogram from the passed db and write it either to a MiniSEED
+    or a SACZIP file.
+
+    :param db: An open instaseis database.
+    :param epicentral_distance_degree: epicentral distance in degree
+    :param source_depth_in_m: source depth in m
+    :param units: The desired units.
+    :param dt: dt to resample to.
+    :param kernelwidth: Width of the interpolation kernel.
+    :param origintime: Origin time of the source.
+    :param starttime: The desired start time of the seismogram.
+    :param endtime: The desired end time of the seismogram.
+    :param format: The output format. Either "miniseed" or "saczip".
+    :param label: Prefix for the filename within the SAC zip file.
+    :param callback: callback function of the coroutine.
+    """
+    if not label:
+        label = ""
+    else:
+        label += "_"
+
+    try:
+        st = db.get_greens_seiscomp(
+            epicentral_distance_degree=epicentral_distance_degree,
+            source_depth_in_m=source_depth_in_m, origin_time=origintime,
+            kind=units, return_obspy_stream=True, dt=dt,
+            kernelwidth=kernelwidth)
+    except Exception:
+        msg = ("Could not extract Green's function. Make sure, the parameters "
+               "are valid, and the depth settings are correct.")
+        callback(tornado.web.HTTPError(400, log_message=msg, reason=msg))
+        return
+
+    for tr in st:
+        # Half the filesize but definitely sufficiently accurate.
+        tr.data = np.require(tr.data, dtype=np.float32)
+
+    # Sanity checks. Raise internal server errors in case something fails.
+    # This should not happen and should have been caught before.
+    if endtime > st[0].stats.endtime:
+        msg = ("Endtime larger then the extracted endtime: endtime=%s, "
+               "largest db endtime=%s" % (endtime, st[0].stats.endtime))
+        callback(tornado.web.HTTPError(500, log_message=msg, reason=msg))
+        return
+    if starttime < st[0].stats.starttime - 3600.0:
+        msg = ("Starttime more than one hour before the starttime of the "
+               "seismograms.")
+        callback(tornado.web.HTTPError(500, log_message=msg, reason=msg))
+        return
+
+    # Trim, potentially pad with zeroes.
+    st.trim(starttime, endtime, pad=True, fill_value=0.0, nearest_sample=False)
+
+    # Checked in another function and just a sanity check.
+    assert format in ("miniseed", "saczip")
+
+    if format == "miniseed":
+        with io.BytesIO() as fh:
+            st.write(fh, format="mseed")
+            fh.seek(0, 0)
+            binary_data = fh.read()
+        callback(binary_data)
+    # Write a number of SAC files into an archive.
+    elif format == "sac":
+        byte_strings = []
+        for tr in st:
+            # Write SAC headers.
+            tr.stats.sac = obspy.core.AttribDict()
+            # Write WGS84 coordinates to the SAC files.
+            tr.stats.sac.stla = geocentric_to_wgs84_latitude(
+                90.0 - epicentral_distance_degree)
+            tr.stats.sac.stlo = 0.0
+            tr.stats.sac.stdp = 0.0
+            tr.stats.sac.stel = 0.0
+            tr.stats.sac.evla = geocentric_to_wgs84_latitude(90.)
+            tr.stats.sac.evlo = 90.
+            tr.stats.sac.evdp = source_depth_in_m
+            # Thats what SPECFEM uses for a moment magnitude....
+            tr.stats.sac.imagtyp = 55
+            # The event origin time relative to the reference which I'll
+            # just assume to be the starttime here?
+            tr.stats.sac.o = origintime - starttime
+
+            with io.BytesIO() as temp:
+                tr.write(temp, format="sac")
+                temp.seek(0, 0)
+                filename = "%s%s.sac" % (label, tr.id)
+                byte_strings.append((filename, temp.read()))
+        callback(byte_strings)
+
+
+class IOQueue(object):
+    """
+    Object passed to the zipfile constructor which acts as a file-like object.
+
+    Iterating over the object yields the data pieces written to it since it
+    has last been iterated over DELETING those pieces at the end of each
+    loop. This enables the server to send unbounded zipfiles without running
+    into memory issues.
+    """
+    def __init__(self):
+        self.count = 0
+        self.data = []
+
+    def flush(self):
+        pass
+
+    def tell(self):
+        return self.count
+
+    def write(self, data):
+        self.data.append(data)
+        self.count += len(data)
+
+    def __iter__(self):
+        for _i in self.data:
+            yield _i
+        self.data = []
+        raise StopIteration
+
+
+def _validtimesetting(value):
+    try:
+        return obspy.UTCDateTime(value)
+    except:
+        pass
+
+    try:
+        return float(value)
+    except:
+        pass
+
+    m = PHASE_OFFSET_PATTERN.match(value)
+    if m is None:
+        raise ValueError
+
+    operator = m.group(2)
+    if operator == "+":
+        offset = float(m.group(3))
+    else:
+        offset = -float(m.group(3))
+
+    return {
+        "phase": m.group(1),
+        "offset": offset
+    }
+
+
+class GreensHandler(InstaseisRequestHandler):
+    # Define the arguments for the Greens endpoint.
+    greens_arguments = {
+        "units": {"type": str, "default": "displacement"},
+        "dt": {"type": float},
+        "kernelwidth": {"type": int, "default": 12},
+        "label": {"type": str},
+
+        # Source parameters.
+        "sourcedistanceindegree": {"type": float, "required": True},
+        "sourcedepthinmeters": {"type": float, "required": True},
+
+        # Time parameters.
+        "origintime": {"type": obspy.UTCDateTime},
+        "starttime": {"type": _validtimesetting,
+                      "format": "Datetime String/Float/Phase+-Offset"},
+        "endtime": {"type": _validtimesetting,
+                    "format": "Datetime String/Float/Phase+-Offset"},
+
+        "format": {"type": str, "default": "saczip"}
+    }
+
+    def __init__(self, *args, **kwargs):
+        self.__connection_closed = False
+        InstaseisRequestHandler.__init__(self, *args, **kwargs)
+
+    def parse_arguments(self):
+        # Make sure that no additional arguments are passed.
+        unknown_arguments = set(self.request.arguments.keys()).difference(set(
+            self.greens_arguments.keys()))
+        if unknown_arguments:
+            msg = "The following unknown parameters have been passed: %s" % (
+                ", ".join("'%s'" % _i for _i in sorted(unknown_arguments)))
+            raise tornado.web.HTTPError(400, log_message=msg,
+                                        reason=msg)
+
+        # Check for duplicates.
+        duplicates = []
+        for key, value in self.request.arguments.items():
+            if len(value) == 1:
+                continue
+            else:
+                duplicates.append(key)
+        if duplicates:
+            msg = "Duplicate parameters: %s" % (
+                ", ".join("'%s'" % _i for _i in sorted(duplicates)))
+            raise tornado.web.HTTPError(400, log_message=msg,
+                                        reason=msg)
+
+        args = obspy.core.AttribDict()
+        for name, properties in self.greens_arguments.items():
+            if "required" in properties:
+                try:
+                    value = self.get_argument(name)
+                except:
+                    msg = "Required parameter '%s' not given." % name
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+            else:
+                if "default" in properties:
+                    default = properties["default"]
+                else:
+                    default = None
+                value = self.get_argument(name, default=default)
+            if value is not None:
+                try:
+                    value = properties["type"](value)
+                except:
+                    if "format" in properties:
+                        msg = "Parameter '%s' must be formatted as: '%s'" % (
+                            name, properties["format"])
+                    else:
+                        msg = ("Parameter '%s' could not be converted to "
+                               "'%s'.") % (
+                            name, str(properties["type"].__name__))
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+            setattr(args, name, value)
+
+        # Validate some of them right here.
+        self.validate_parameters(args)
+
+        return args
+
+    def on_connection_close(self):
+        """
+        Called when the client cancels the connection. Then the loop
+        requesting seismograms will stop.
+        """
+        InstaseisRequestHandler.on_connection_close(self)
+        self.__connection_closed = True
+
+    def validate_parameters(self, args):
+        """
+        Function attempting to validate that the passed parameters are
+        valid. Does not need to check the types as that has already been done.
+        """
+        info = self.application.db.info
+
+        # greens functions only work with reciprocal databases
+        if not info.is_reciprocal:
+            msg = ("The database is not reciprocal, "
+                   "so Green's functions can't be computed.")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # Make sure, epicentral disance and source depth are in reasonable
+        # ranges
+        if args.sourcedistanceindegree is not None and \
+                not 0.0 <= args.sourcedistanceindegree <= 180.0:
+            msg = ("Epicentral distance should be in [0, 180].")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+        if args.sourcedepthinmeters is not None and \
+                not 0.0 <= args.sourcedepthinmeters <= info.planet_radius:
+            msg = ("Source depth should be in [0, planet radius].")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # Make sure the unit arguments is valid.
+        args.units = args.units.lower()
+        if args.units not in ["displacement", "velocity", "acceleration"]:
+            msg = ("Unit must be one of 'displacement', 'velocity', "
+                   "or 'acceleration'")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # Make sure the output format is valid.
+        args.format = args.format.lower()
+        if args.format not in ("miniseed", "saczip"):
+            msg = ("Format must either be 'miniseed' or 'saczip'.")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # If its essentially equal to the internal sampling rate just set it
+        # to equal to ease the following comparisons.
+        if args.dt and abs(args.dt - info.dt) / args.dt < 1E-7:
+            args.dt = info.dt
+
+        # Make sure that dt, if given is larger then 0.01. This should still
+        # be plenty for any use case but prevents the server from having to
+        # send massive amounts of data in the case of user errors.
+        if args.dt is not None and args.dt < 0.01:
+            msg = ("The smallest possible dt is 0.01. Please choose a "
+                   "smaller value and resample locally if needed.")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # Also make sure it does not downsample.
+        if args.dt is not None and args.dt > info.dt:
+            msg = ("Cannot downsample. The sampling interval of the database "
+                   "is %.5f seconds. Make sure to choose a smaller or equal "
+                   "one." % info.dt)
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # Make sure the interpolation kernel width is sensible. Don't allow
+        # values smaller than 1 or larger than 20.
+        if not (1 <= args.kernelwidth <= 20):
+            msg = ("`kernelwidth` must not be smaller than 1 or larger than "
+                   "20.")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+    def parse_time_settings(self, args):
+        """
+        Attempt to figure out the time settings.
+
+        This is pretty messy unfortunately. After this method has been
+        called, args.origintime will always be set to an absolute time.
+
+        args.starttime and args.endtime will either be set to absolute times
+        or dictionaries describing phase relative offsets.
+
+        Returns the minium possible start- and the maximum possible endtime.
+        """
+        if args.origintime is None:
+            args.origintime = obspy.UTCDateTime(0)
+
+        # The origin time will be always set. If the starttime is not set,
+        # set it to the origin time.
+        if args.starttime is None:
+            args.starttime = args.origintime
+
+        # Now it becomes a bit ugly. If the starttime is a float, treat it
+        # relative to the origin time.
+        if isinstance(args.starttime, float):
+            args.starttime = args.origintime + args.starttime
+
+        # Now deal with the endtime.
+        if isinstance(args.endtime, float):
+            # If the start time is already known as an absolute time,
+            # just add it.
+            if isinstance(args.starttime, obspy.UTCDateTime):
+                args.endtime = args.starttime + args.endtime
+            else:
+                assert isinstance(args.starttime, obspy.core.AttribDict)
+
+        # Figure out the maximum temporal range of the seismograms.
+        ti = _get_seismogram_times(
+            info=self.application.db.info, origin_time=args.origintime,
+            dt=args.dt, kernelwidth=args.kernelwidth,
+            remove_source_shift=False, reconvolve_stf=False)
+
+        # If the endtime is not set, do it here.
+        if args.endtime is None:
+            args.endtime = ti["endtime"]
+
+        # Do a couple of sanity checks here.
+        if isinstance(args.starttime, obspy.UTCDateTime):
+            # The desired seismogram start time must be before the end time of
+            # the seismograms.
+            if args.starttime >= ti["endtime"]:
+                msg = ("The `starttime` must be before the seismogram ends.")
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+            # Arbitrary limit: The starttime can be at max one hour before the
+            # origin time.
+            if args.starttime < (ti["starttime"] - 3600):
+                msg = ("The seismogram can start at the maximum one hour "
+                       "before the origin time.")
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        if isinstance(args.endtime, obspy.UTCDateTime):
+            # The endtime must be within the seismogram window
+            if not (ti["starttime"] <= args.endtime <= ti["endtime"]):
+                msg = ("The end time of the seismograms lies outside the "
+                       "allowed range.")
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        return ti["starttime"], ti["endtime"]
+
+    def set_headers(self, args):
+        if args.format == "miniseed":
+            content_type = "application/octet-stream"
+        elif args.format == "saczip":
+            content_type = "application/zip"
+        self.set_header("Content-Type", content_type)
+
+        FILE_ENDINGS_MAP = {
+            "miniseed": "mseed",
+            "saczip": "zip"}
+
+        if args.label:
+            label = args.label
+        else:
+            label = "instaseis_greens"
+
+        filename = "%s_%s.%s" % (
+            label,
+            str(obspy.UTCDateTime()).replace(":", "_"),
+            FILE_ENDINGS_MAP[args.format])
+
+        self.set_header("Content-Disposition",
+                        "attachment; filename=%s" % filename)
+
+    def get_ttime(self, source, receiver, phase):
+        if self.application.travel_time_callback is None:
+            msg = "Server does not support travel time calculations."
+            raise tornado.web.HTTPError(
+                404, log_message=msg, reason=msg)
+        try:
+            tt = self.application.travel_time_callback(
+                sourcelatitude=source.latitude,
+                sourcelongitude=source.longitude,
+                sourcedepthinmeters=source.depth_in_m,
+                receiverlatitude=receiver.latitude,
+                receiverlongitude=receiver.longitude,
+                receiverdepthinmeters=receiver.depth_in_m,
+                phase_name=phase)
+        except ValueError as e:
+            err_msg = str(e)
+            if err_msg.lower().startswith("invalid phase name"):
+                msg = "Invalid phase name: %s" % phase
+            else:
+                msg = "Failed to calculate travel time due to: %s" % err_msg
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+        return tt
+
+    def validate_geometry(self, source, receiver):
+        """
+        Validate the source-receiver geometry.
+        """
+        info = self.application.db.info
+
+        # XXX: Will have to be changed once we have a database recorded for
+        # example on the ocean bottom.
+        if info.is_reciprocal:
+            # Receiver must be at the surface.
+            if receiver.depth_in_m is not None:
+                if receiver.depth_in_m != 0.0:
+                    msg = "Receiver must be at the surface for reciprocal " \
+                          "databases."
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+            # Source depth must be within the allowed range.
+            if not ((info.planet_radius - info.max_radius) <=
+                    source.depth_in_m <=
+                    (info.planet_radius - info.min_radius)):
+                msg = ("Source depth must be within the database range: %.1f "
+                       "- %.1f meters.") % (
+                        info.planet_radius - info.max_radius,
+                        info.planet_radius - info.min_radius)
+                raise tornado.web.HTTPError(400, log_message=msg,
+                                            reason=msg)
+        else:
+            # The source depth must coincide with the one in the database.
+            if source.depth_in_m != info.source_depth * 1000:
+                    msg = "Source depth must be: %.1f km" % info.source_depth
+                    raise tornado.web.HTTPError(400, log_message=msg,
+                                                reason=msg)
+
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
+    def get(self):
+        # Parse the arguments. This will also perform a number of sanity
+        # checks.
+        args = self.parse_arguments()
+
+        min_starttime, max_endtime = self.parse_time_settings(args)
+        self.set_headers(args)
+
+        # generating source and receiver as in the get_greens routine of the
+        # base_instaseis class
+        src_latitude, src_longitude = 90., 0.
+        rec_latitude, rec_longitude = 90. - args.sourcedistanceindegree, 0.
+        source = Source(src_latitude, src_longitude, args.sourcedepthinmeters)
+        receivers = [Receiver(rec_latitude, rec_longitude)]
+
+        # If a zip file is requested, initialize it here and write to custom
+        # buffer object.
+        if args.format == "saczip":
+            buf = IOQueue()
+            zip_file = zipfile.ZipFile(buf, mode="w")
+
+        # Count the number of successful extractions. Phase relative offsets
+        # could result in no actually calculated seismograms. In that case
+        # we would like to raise an error.
+        count = 0
+
+        # XXX: only one reqest here, keeping the loop structure to enable the
+        # 'count' test as in the seismograms route
+        for receiver in receivers:
+            # Check if the connection is still open. The __connection_closed
+            # flag is set by the on_connection_close() method. This is
+            # pretty manual right now. Maybe there is a better way? This
+            # enables to server to stop serving if the connection has been
+            # cancelled on the client side.
+            if self.__connection_closed:
+                self.flush()
+                self.finish()
+                return
+
+            # Check if start- or end time are phase relative. If yes
+            # calculate the new start- and/or end time.
+            if isinstance(args.starttime, obspy.core.AttribDict):
+                tt = self.get_ttime(source=source, receiver=receiver,
+                                    phase=args.starttime["phase"])
+                if tt is None:
+                    continue
+                starttime = args.origintime + tt + args.starttime["offset"]
+            else:
+                starttime = args.starttime
+
+            if starttime < min_starttime - 3600.0:
+                continue
+
+            if isinstance(args.endtime, obspy.core.AttribDict):
+                tt = self.get_ttime(source=source, receiver=receiver,
+                                    phase=args.endtime["phase"])
+                if tt is None:
+                    continue
+                endtime = args.origintime + tt + args.endtime["offset"]
+            # Endtime relative to phase relative starttime.
+            elif isinstance(args.endtime, float):
+                endtime = starttime + args.endtime
+            else:
+                endtime = args.endtime
+
+            if endtime > max_endtime:
+                continue
+
+            # Validate the source-receiver geometry.
+            self.validate_geometry(source=source, receiver=receiver)
+
+            # Yield from the task. This enables a context switch and thus
+            # async behaviour.
+            response = yield tornado.gen.Task(
+                _get_greens,
+                db=self.application.db,
+                epicentral_distance_degree=args.sourcedistanceindegree,
+                source_depth_in_m=args.sourcedepthinmeters, units=args.units,
+                dt=args.dt, kernelwidth=args.kernelwidth,
+                origintime=args.origintime, starttime=starttime,
+                endtime=endtime, format=args.format, label=args.label)
+
+            # If an exception is returned from the task, re-raise it here.
+            if isinstance(response, Exception):
+                raise response
+            # It might return a list, in that case each item is a bytestring
+            # of SAC file.
+            elif isinstance(response, list):
+                assert args.format == "saczip"
+                for filename, content in response:
+                    zip_file.writestr(filename, content)
+                for data in buf:
+                    self.write(data)
+            # Otherwise it contain MiniSEED which can just directly be
+            # streamed.
+            else:
+                self.write(response)
+            self.flush()
+
+            count += 1
+
+        # If nothing is written, raise an error. This should really only
+        # happen with phase relative offsets with phases not coinciding with
+        # the source - receiver geometry.
+        if not count:
+            msg = ("No seismograms found for the given phase relative "
+                   "offsets. This could either be due to the chosen phase "
+                   "not existing for the specific source-receiver geometry "
+                   "or arriving too late/with too large offsets if the "
+                   "database is not long enough.")
+            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        # Write the end of the zipfile in case necessary.
+        if args.format == "saczip":
+            zip_file.close()
+            for data in buf:
+                self.write(data)
+
+        self.finish()

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -19,7 +19,7 @@ import tornado.web
 from ... import Source, Receiver
 from ...base_instaseis_db import _get_seismogram_times
 from ..util import run_async, IOQueue, _validtimesetting
-from ..instaseis_request import InstaseisRequestHandler
+from ..instaseis_request import InstaseisTimeSeriesHandler
 from ...helpers import geocentric_to_wgs84_latitude
 
 
@@ -119,9 +119,9 @@ def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
         callback(byte_strings)
 
 
-class GreensHandler(InstaseisRequestHandler):
+class GreensHandler(InstaseisTimeSeriesHandler):
     # Define the arguments for the Greens endpoint.
-    greens_arguments = {
+    arguments = {
         "units": {"type": str, "default": "displacement"},
         "dt": {"type": float},
         "kernelwidth": {"type": int, "default": 12},
@@ -143,72 +143,14 @@ class GreensHandler(InstaseisRequestHandler):
 
     def __init__(self, *args, **kwargs):
         self.__connection_closed = False
-        InstaseisRequestHandler.__init__(self, *args, **kwargs)
-
-    def parse_arguments(self):
-        # Make sure that no additional arguments are passed.
-        unknown_arguments = set(self.request.arguments.keys()).difference(set(
-            self.greens_arguments.keys()))
-        if unknown_arguments:
-            msg = "The following unknown parameters have been passed: %s" % (
-                ", ".join("'%s'" % _i for _i in sorted(unknown_arguments)))
-            raise tornado.web.HTTPError(400, log_message=msg,
-                                        reason=msg)
-
-        # Check for duplicates.
-        duplicates = []
-        for key, value in self.request.arguments.items():
-            if len(value) == 1:
-                continue
-            else:
-                duplicates.append(key)
-        if duplicates:
-            msg = "Duplicate parameters: %s" % (
-                ", ".join("'%s'" % _i for _i in sorted(duplicates)))
-            raise tornado.web.HTTPError(400, log_message=msg,
-                                        reason=msg)
-
-        args = obspy.core.AttribDict()
-        for name, properties in self.greens_arguments.items():
-            if "required" in properties:
-                try:
-                    value = self.get_argument(name)
-                except:
-                    msg = "Required parameter '%s' not given." % name
-                    raise tornado.web.HTTPError(400, log_message=msg,
-                                                reason=msg)
-            else:
-                if "default" in properties:
-                    default = properties["default"]
-                else:
-                    default = None
-                value = self.get_argument(name, default=default)
-            if value is not None:
-                try:
-                    value = properties["type"](value)
-                except:
-                    if "format" in properties:
-                        msg = "Parameter '%s' must be formatted as: '%s'" % (
-                            name, properties["format"])
-                    else:
-                        msg = ("Parameter '%s' could not be converted to "
-                               "'%s'.") % (
-                            name, str(properties["type"].__name__))
-                    raise tornado.web.HTTPError(400, log_message=msg,
-                                                reason=msg)
-            setattr(args, name, value)
-
-        # Validate some of them right here.
-        self.validate_parameters(args)
-
-        return args
+        InstaseisTimeSeriesHandler.__init__(self, *args, **kwargs)
 
     def on_connection_close(self):
         """
         Called when the client cancels the connection. Then the loop
         requesting seismograms will stop.
         """
-        InstaseisRequestHandler.on_connection_close(self)
+        InstaseisTimeSeriesHandler.on_connection_close(self)
         self.__connection_closed = True
 
     def validate_parameters(self, args):

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -306,6 +306,8 @@ class GreensHandler(InstaseisRequestHandler):
             # just add it.
             if isinstance(args.starttime, obspy.UTCDateTime):
                 args.endtime = args.starttime + args.endtime
+            # Otherwise the start time has to be a phase relative time and
+            # is dealt with later.
             else:
                 assert isinstance(args.starttime, obspy.core.AttribDict)
 

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -50,7 +50,7 @@ def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
 
     try:
         st = db.get_greens_seiscomp(
-            epicentral_distance_degree=epicentral_distance_degree,
+            epicentral_distance_in_degree=epicentral_distance_degree,
             source_depth_in_m=source_depth_in_m, origin_time=origintime,
             kind=units, return_obspy_stream=True, dt=dt,
             kernelwidth=kernelwidth)
@@ -101,8 +101,8 @@ def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
             tr.stats.sac.stlo = 0.0
             tr.stats.sac.stdp = 0.0
             tr.stats.sac.stel = 0.0
-            tr.stats.sac.evla = geocentric_to_wgs84_latitude(90.)
-            tr.stats.sac.evlo = 90.
+            tr.stats.sac.evla = 90.0
+            tr.stats.sac.evlo = 90.0
             tr.stats.sac.evdp = source_depth_in_m
             # Thats what SPECFEM uses for a moment magnitude....
             tr.stats.sac.imagtyp = 55
@@ -127,7 +127,7 @@ class GreensHandler(InstaseisTimeSeriesHandler):
         "label": {"type": str},
 
         # Source parameters.
-        "sourcedistanceindegree": {"type": float, "required": True},
+        "sourcedistanceindegrees": {"type": float, "required": True},
         "sourcedepthinmeters": {"type": float, "required": True},
 
         # Time parameters.
@@ -158,8 +158,8 @@ class GreensHandler(InstaseisTimeSeriesHandler):
 
         # Make sure, epicentral disance and source depth are in reasonable
         # ranges
-        if args.sourcedistanceindegree is not None and \
-                not 0.0 <= args.sourcedistanceindegree <= 180.0:
+        if args.sourcedistanceindegrees is not None and \
+                not 0.0 <= args.sourcedistanceindegrees <= 180.0:
             msg = ("Epicentral distance should be in [0, 180].")
             raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
         if args.sourcedepthinmeters is not None and \
@@ -220,7 +220,7 @@ class GreensHandler(InstaseisTimeSeriesHandler):
         # generating source and receiver as in the get_greens routine of the
         # base_instaseis class
         src_latitude, src_longitude = 90., 0.
-        rec_latitude, rec_longitude = 90. - args.sourcedistanceindegree, 0.
+        rec_latitude, rec_longitude = 90. - args.sourcedistanceindegrees, 0.
         source = Source(src_latitude, src_longitude, args.sourcedepthinmeters)
         receivers = [Receiver(rec_latitude, rec_longitude)]
 
@@ -285,7 +285,7 @@ class GreensHandler(InstaseisTimeSeriesHandler):
             response = yield tornado.gen.Task(
                 _get_greens,
                 db=self.application.db,
-                epicentral_distance_degree=args.sourcedistanceindegree,
+                epicentral_distance_degree=args.sourcedistanceindegrees,
                 source_depth_in_m=args.sourcedepthinmeters, units=args.units,
                 dt=args.dt, kernelwidth=args.kernelwidth,
                 origintime=args.origintime, starttime=starttime,

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -49,11 +49,11 @@ def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
         label += "_"
 
     try:
-        st = db.get_greens_seiscomp(
+        st = db.get_greens_function(
             epicentral_distance_in_degree=epicentral_distance_degree,
             source_depth_in_m=source_depth_in_m, origin_time=origintime,
             kind=units, return_obspy_stream=True, dt=dt,
-            kernelwidth=kernelwidth)
+            kernelwidth=kernelwidth, definition="seiscomp")
     except Exception:
         msg = ("Could not extract Green's function. Make sure, the parameters "
                "are valid, and the depth settings are correct.")

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -16,7 +16,6 @@ import tornado.gen
 import tornado.web
 
 from ... import Source, ForceSource, Receiver
-from ...base_instaseis_db import _get_seismogram_times
 from ..util import run_async, IOQueue, _validtimesetting
 from ..instaseis_request import InstaseisTimeSeriesHandler
 from ...helpers import geocentric_to_wgs84_latitude
@@ -189,16 +188,7 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
     }
 
     def __init__(self, *args, **kwargs):
-        self.__connection_closed = False
-        InstaseisTimeSeriesHandler.__init__(self, *args, **kwargs)
-
-    def on_connection_close(self):
-        """
-        Called when the client cancels the connection. Then the loop
-        requesting seismograms will stop.
-        """
-        InstaseisTimeSeriesHandler.on_connection_close(self)
-        self.__connection_closed = True
+        super(InstaseisTimeSeriesHandler, self).__init__(*args, **kwargs)
 
     def validate_parameters(self, args):
         """
@@ -469,155 +459,6 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
                                                 reason=msg)
         return receivers
 
-    def parse_time_settings(self, args):
-        """
-        Attempt to figure out the time settings.
-
-        This is pretty messy unfortunately. After this method has been
-        called, args.origintime will always be set to an absolute time.
-
-        args.starttime and args.endtime will either be set to absolute times
-        or dictionaries describing phase relative offsets.
-
-        Returns the minium possible start- and the maximum possible endtime.
-        """
-        if args.origintime is None:
-            args.origintime = obspy.UTCDateTime(0)
-
-        # The origin time will be always set. If the starttime is not set,
-        # set it to the origin time.
-        if args.starttime is None:
-            args.starttime = args.origintime
-
-        # Now it becomes a bit ugly. If the starttime is a float, treat it
-        # relative to the origin time.
-        if isinstance(args.starttime, float):
-            args.starttime = args.origintime + args.starttime
-
-        # Now deal with the endtime.
-        if isinstance(args.endtime, float):
-            # If the start time is already known as an absolute time,
-            # just add it.
-            if isinstance(args.starttime, obspy.UTCDateTime):
-                args.endtime = args.starttime + args.endtime
-            # Otherwise the start time has to be a phase relative time and
-            # is dealt with later.
-            else:
-                assert isinstance(args.starttime, obspy.core.AttribDict)
-
-        # Figure out the maximum temporal range of the seismograms.
-        ti = _get_seismogram_times(
-            info=self.application.db.info, origin_time=args.origintime,
-            dt=args.dt, kernelwidth=args.kernelwidth,
-            remove_source_shift=False, reconvolve_stf=False)
-
-        # If the endtime is not set, do it here.
-        if args.endtime is None:
-            args.endtime = ti["endtime"]
-
-        # Do a couple of sanity checks here.
-        if isinstance(args.starttime, obspy.UTCDateTime):
-            # The desired seismogram start time must be before the end time of
-            # the seismograms.
-            if args.starttime >= ti["endtime"]:
-                msg = ("The `starttime` must be before the seismogram ends.")
-                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-            # Arbitrary limit: The starttime can be at max one hour before the
-            # origin time.
-            if args.starttime < (ti["starttime"] - 3600):
-                msg = ("The seismogram can start at the maximum one hour "
-                       "before the origin time.")
-                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-
-        if isinstance(args.endtime, obspy.UTCDateTime):
-            # The endtime must be within the seismogram window
-            if not (ti["starttime"] <= args.endtime <= ti["endtime"]):
-                msg = ("The end time of the seismograms lies outside the "
-                       "allowed range.")
-                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-
-        return ti["starttime"], ti["endtime"]
-
-    def set_headers(self, args):
-        if args.format == "miniseed":
-            content_type = "application/octet-stream"
-        elif args.format == "saczip":
-            content_type = "application/zip"
-        self.set_header("Content-Type", content_type)
-
-        FILE_ENDINGS_MAP = {
-            "miniseed": "mseed",
-            "saczip": "zip"}
-
-        if args.label:
-            label = args.label
-        else:
-            label = "instaseis_seismogram"
-
-        filename = "%s_%s.%s" % (
-            label,
-            str(obspy.UTCDateTime()).replace(":", "_"),
-            FILE_ENDINGS_MAP[args.format])
-
-        self.set_header("Content-Disposition",
-                        "attachment; filename=%s" % filename)
-
-    def get_ttime(self, source, receiver, phase):
-        if self.application.travel_time_callback is None:
-            msg = "Server does not support travel time calculations."
-            raise tornado.web.HTTPError(
-                404, log_message=msg, reason=msg)
-        try:
-            tt = self.application.travel_time_callback(
-                sourcelatitude=source.latitude,
-                sourcelongitude=source.longitude,
-                sourcedepthinmeters=source.depth_in_m,
-                receiverlatitude=receiver.latitude,
-                receiverlongitude=receiver.longitude,
-                receiverdepthinmeters=receiver.depth_in_m,
-                phase_name=phase)
-        except ValueError as e:
-            err_msg = str(e)
-            if err_msg.lower().startswith("invalid phase name"):
-                msg = "Invalid phase name: %s" % phase
-            else:
-                msg = "Failed to calculate travel time due to: %s" % err_msg
-            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
-        return tt
-
-    def validate_geometry(self, source, receiver):
-        """
-        Validate the source-receiver geometry.
-        """
-        info = self.application.db.info
-
-        # XXX: Will have to be changed once we have a database recorded for
-        # example on the ocean bottom.
-        if info.is_reciprocal:
-            # Receiver must be at the surface.
-            if receiver.depth_in_m is not None:
-                if receiver.depth_in_m != 0.0:
-                    msg = "Receiver must be at the surface for reciprocal " \
-                          "databases."
-                    raise tornado.web.HTTPError(400, log_message=msg,
-                                                reason=msg)
-            # Source depth must be within the allowed range.
-            if not ((info.planet_radius - info.max_radius) <=
-                    source.depth_in_m <=
-                    (info.planet_radius - info.min_radius)):
-                msg = ("Source depth must be within the database range: %.1f "
-                       "- %.1f meters.") % (
-                        info.planet_radius - info.max_radius,
-                        info.planet_radius - info.min_radius)
-                raise tornado.web.HTTPError(400, log_message=msg,
-                                            reason=msg)
-        else:
-            # The source depth must coincide with the one in the database.
-            if source.depth_in_m != info.source_depth * 1000:
-                    msg = "Source depth must be: %.1f km" % info.source_depth
-                    raise tornado.web.HTTPError(400, log_message=msg,
-                                                reason=msg)
-
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
@@ -651,7 +492,7 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
             __event = None
 
         min_starttime, max_endtime = self.parse_time_settings(args)
-        self.set_headers(args)
+        self.set_headers("instaseis_seismogram", args)
 
         source = self.get_source(args, __event)
 
@@ -675,12 +516,12 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
         # user.
         for receiver in receivers:
 
-            # Check if the connection is still open. The __connection_closed
+            # Check if the connection is still open. The connection_closed
             # flag is set by the on_connection_close() method. This is
             # pretty manual right now. Maybe there is a better way? This
             # enables to server to stop serving if the connection has been
             # cancelled on the client side.
-            if self.__connection_closed:
+            if self.connection_closed:
                 self.flush()
                 self.finish()
                 return

--- a/instaseis/server/routes/seismograms_raw.py
+++ b/instaseis/server/routes/seismograms_raw.py
@@ -52,7 +52,6 @@ class RawSeismogramsHandler(InstaseisTimeSeriesHandler):
         "stationcode": {"type": str}
     }
 
-
     def get(self):
         args = self.parse_arguments()
 

--- a/instaseis/server/routes/seismograms_raw.py
+++ b/instaseis/server/routes/seismograms_raw.py
@@ -15,6 +15,52 @@ import tornado.web
 
 from ... import Source, ForceSource, Receiver
 from ..instaseis_request import InstaseisTimeSeriesHandler
+from ..util import run_async
+
+
+@run_async
+def _get_seismogram(db, source, receiver, components, callback):
+    """
+    Extract a seismogram from the passed db and write it either to a MiniSEED
+    or a SACZIP file.
+
+    :param db: An open instaseis database.
+    :param source: An instaseis source.
+    :param receiver: An instaseis receiver.
+    :param components: The components.
+    :param callback: callback function of the coroutine.
+    """
+    # Get the most barebones seismograms possible.
+    try:
+        db._get_seismograms_sanity_checks(
+            source=source, receiver=receiver, components=components,
+            kind="displacement")
+        data = db._get_seismograms(
+            source=source, receiver=receiver, components=components)
+    except Exception:
+        msg = ("Could not extract seismogram. Make sure, the components "
+               "are valid, and the depth settings are correct.")
+        callback(tornado.web.HTTPError(400, log_message=msg, reason=msg))
+        return
+
+    try:
+        st = db._convert_to_stream(
+            receiver=receiver, components=components,
+            data=data, dt_out=db.info.dt, starttime=source.origin_time)
+    except Exception:
+        msg = ("Could not convert seismogram to a Stream object.")
+        callback(tornado.web.HTTPError(500, log_message=msg, reason=msg))
+        return
+
+    # Half the filesize but definitely sufficiently accurate.
+    for tr in st:
+        tr.data = np.require(tr.data, dtype=np.float32)
+
+    with io.BytesIO() as fh:
+        st.write(fh, format="mseed")
+        fh.seek(0, 0)
+        binary_data = fh.read()
+    callback((binary_data, st[0].stats.instaseis.mu))
 
 
 class RawSeismogramsHandler(InstaseisTimeSeriesHandler):
@@ -56,6 +102,8 @@ class RawSeismogramsHandler(InstaseisTimeSeriesHandler):
     def validate_parameters(self, args):
         pass
 
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def get(self):
         args = self.parse_arguments()
 
@@ -135,39 +183,18 @@ class RawSeismogramsHandler(InstaseisTimeSeriesHandler):
                    "Check parameters for sanity.")
             raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
 
-        # Get the most barebones seismograms possible.
-        try:
-            self.application.db._get_seismograms_sanity_checks(
-                source=source, receiver=receiver, components=components,
-                kind="displacement")
-            data = self.application.db._get_seismograms(
-                source=source, receiver=receiver, components=components)
-        except Exception:
-            msg = ("Could not extract seismogram. Make sure, the components "
-                   "are valid, and the depth settings are correct.")
-            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+        response = yield tornado.gen.Task(
+            _get_seismogram, db=self.application.db, source=source,
+            receiver=receiver, components=components)
 
-        try:
-            st = self.application.db._convert_to_stream(
-                receiver=receiver, components=components,
-                data=data, dt_out=self.application.db.info.dt,
-                starttime=args.origintime)
-        except Exception:
-            msg = ("Could not convert seismogram to a Stream object.")
-            raise tornado.web.HTTPError(500, log_message=msg, reason=msg)
-
-        # Half the filesize but definitely sufficiently accurate.
-        for tr in st:
-            tr.data = np.require(tr.data, dtype=np.float32)
-
-        with io.BytesIO() as fh:
-            st.write(fh, format="mseed")
-            fh.seek(0, 0)
-            binary_data = fh.read()
+        # If an exception is returned from the task, re-raise it here.
+        if isinstance(response, Exception):
+            raise response
 
         self.set_headers(args)
         # Passing mu in the HTTP header...not sure how well this plays with
         # proxies...
-        self.set_header("Instaseis-Mu", "%f" % st[0].stats.instaseis.mu)
+        self.set_header("Instaseis-Mu", "%f" % response[1])
 
-        self.write(binary_data)
+        self.write(response[0])
+        self.finish()

--- a/instaseis/server/util.py
+++ b/instaseis/server/util.py
@@ -7,8 +7,13 @@
     GNU Lesser General Public License, Version 3 [non-commercial/academic use]
     (http://www.gnu.org/copyleft/lgpl.html)
 """
+import re
 import functools
 import threading
+import obspy
+
+# Valid phase offset pattern including capture groups.
+PHASE_OFFSET_PATTERN = re.compile(r"(^[A-Za-z0-9^]+)([\+-])([\deE\.\-\+]+$)")
 
 
 def run_async(func):
@@ -23,3 +28,60 @@ def run_async(func):
         func_hl.start()
         return func_hl
     return async_func
+
+
+class IOQueue(object):
+    """
+    Object passed to the zipfile constructor which acts as a file-like object.
+
+    Iterating over the object yields the data pieces written to it since it
+    has last been iterated over DELETING those pieces at the end of each
+    loop. This enables the server to send unbounded zipfiles without running
+    into memory issues.
+    """
+    def __init__(self):
+        self.count = 0
+        self.data = []
+
+    def flush(self):
+        pass
+
+    def tell(self):
+        return self.count
+
+    def write(self, data):
+        self.data.append(data)
+        self.count += len(data)
+
+    def __iter__(self):
+        for _i in self.data:
+            yield _i
+        self.data = []
+        raise StopIteration
+
+
+def _validtimesetting(value):
+    try:
+        return obspy.UTCDateTime(value)
+    except:
+        pass
+
+    try:
+        return float(value)
+    except:
+        pass
+
+    m = PHASE_OFFSET_PATTERN.match(value)
+    if m is None:
+        raise ValueError
+
+    operator = m.group(2)
+    if operator == "+":
+        offset = float(m.group(3))
+    else:
+        offset = -float(m.group(3))
+
+    return {
+        "phase": m.group(1),
+        "offset": offset
+    }

--- a/instaseis/tests/test_instaseis.py
+++ b/instaseis/tests/test_instaseis.py
@@ -531,7 +531,7 @@ def test_get_greens_vs_get_seismogram():
                                uz, rtol=1E-3, atol=1E-10)
 
     # it seems the definition of 'radial' is different between Minson & Dreger
-    # and Issue 8 by a sign!
+    # and Issue 8 by a sign! Probably related to the definition of z - up
     np.testing.assert_allclose(st_ref.select(component="R")[0].data,
                                -ur, rtol=1E-3, atol=1E-10)
 

--- a/instaseis/tests/test_instaseis.py
+++ b/instaseis/tests/test_instaseis.py
@@ -467,6 +467,78 @@ def test_incremental_bwd_force_source():
                                BWD_FORCE_TEST_DATA["T"], rtol=1E-7, atol=1E-12)
 
 
+def test_get_greens_vs_get_seismogram():
+    """
+    Test get_greens_seiscomp() against default get_seismograms()
+    """
+    db = InstaseisDB(os.path.join(DATA, "100s_db_bwd_displ_only"))
+
+    depth_in_m = 1000
+    epicentral_distance_degree = 20
+    azimuth = 177.
+
+    # some 'random' moment tensor
+    Mxx, Myy, Mzz, Mxz, Myz, Mxy = 1e20, 0.5e20, 0.3e20, 0.7e20, 0.4e20, 0.6e20
+
+    # in Minson & Dreger, 2008, z is up, so we have
+    # Mtt = Mxx, Mpp = Myy, Mrr = Mzz
+    # Mrp = Myz, Mrt = Mxz, Mtp = Mxy
+    source = Source(latitude=90., longitude=0., depth_in_m=depth_in_m,
+                    m_tt=Mxx, m_pp=Myy, m_rr=Mzz, m_rt=Mxz, m_rp=Myz, m_tp=Mxy)
+    receiver = Receiver(latitude=90. - epicentral_distance_degree,
+                        longitude=azimuth)
+
+    st_ref = db.get_seismograms(source, receiver, components=('Z', 'R', 'T'))
+
+    st_greens = db.get_greens_seiscomp(epicentral_distance_degree, depth_in_m)
+
+    TSS = st_greens.select(channel="TSS")[0].data
+    ZSS = st_greens.select(channel="ZSS")[0].data
+    RSS = st_greens.select(channel="RSS")[0].data
+    TDS = st_greens.select(channel="TDS")[0].data
+    ZDS = st_greens.select(channel="ZDS")[0].data
+    RDS = st_greens.select(channel="RDS")[0].data
+    ZDD = st_greens.select(channel="ZDD")[0].data
+    RDD = st_greens.select(channel="RDD")[0].data
+    ZEP = st_greens.select(channel="ZEP")[0].data
+    REP = st_greens.select(channel="REP")[0].data
+
+    az = np.deg2rad(azimuth)
+    # eq (6) in Minson & Dreger, 2008
+    uz = Mxx * (ZSS / 2. * np.cos(2 * az) - ZDD / 6. + ZEP / 3.) \
+        + Myy * (-ZSS / 2. * np.cos(2 * az) - ZDD / 6. + ZEP / 3.) \
+        + Mzz * (ZDD / 3. + ZEP / 3.) \
+        + Mxy * ZSS * np.sin(2 * az) \
+        + Mxz * ZDS * np.cos(az) \
+        + Myz * ZDS * np.sin(az)
+
+    # eq (7) in Minson & Dreger, 2008
+    ur = Mxx * (RSS / 2. * np.cos(2 * az) - RDD / 6. + REP / 3.) \
+        + Myy * (-RSS / 2. * np.cos(2 * az) - RDD / 6. + REP / 3.) \
+        + Mzz * (RDD / 3. + REP / 3.) \
+        + Mxy * RSS * np.sin(2 * az) \
+        + Mxz * RDS * np.cos(az) \
+        + Myz * RDS * np.sin(az)
+
+    # eq (8) in Minson & Dreger, 2008
+    ut = Mxx * TSS / 2. * np.sin(2 * az) \
+        - Myy * TSS / 2. * np.sin(2 * az) \
+        - Mxy * TSS * np.cos(2 * az) \
+        + Mxz * TDS * np.sin(az) \
+        - Myz * TDS * np.cos(az)
+
+    np.testing.assert_allclose(st_ref.select(component="Z")[0].data,
+                               uz, rtol=1E-3, atol=1E-10)
+
+    # it seems the definition of 'radial' is different between Minson & Dreger
+    # and Issue 8 by a sign!
+    np.testing.assert_allclose(st_ref.select(component="R")[0].data,
+                               -ur, rtol=1E-3, atol=1E-10)
+
+    np.testing.assert_allclose(st_ref.select(component="T")[0].data,
+                               ut, rtol=1E-3, atol=1E-10)
+
+
 def test_finite_source():
     """
     incremental tests of bwd mode with source force

--- a/instaseis/tests/test_instaseis.py
+++ b/instaseis/tests/test_instaseis.py
@@ -469,7 +469,7 @@ def test_incremental_bwd_force_source():
 
 def test_get_greens_vs_get_seismogram():
     """
-    Test get_greens_seiscomp() against default get_seismograms()
+    Test get_greens_function() against default get_seismograms()
     """
     db = InstaseisDB(os.path.join(DATA, "100s_db_bwd_displ_only"))
 
@@ -490,7 +490,8 @@ def test_get_greens_vs_get_seismogram():
 
     st_ref = db.get_seismograms(source, receiver, components=('Z', 'R', 'T'))
 
-    st_greens = db.get_greens_seiscomp(epicentral_distance_degree, depth_in_m)
+    st_greens = db.get_greens_function(epicentral_distance_degree,
+                                       depth_in_m, definition="seiscomp")
 
     TSS = st_greens.select(channel="TSS")[0].data
     ZSS = st_greens.select(channel="ZSS")[0].data

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -103,8 +103,8 @@ def test_greens_error_handling(all_clients):
         "sourcedepthinmeters": client.source_depth,
         "sourcedistanceindegrees": 20}
 
-    # get_greens_seiscomp() only works with reciprocal DBs. So make sure we get
-    # the error, but then do the other tests only for reciprocal DBs
+    # get_greens_function() only works with reciprocal DBs. So make sure we
+    # get the error, but then do the other tests only for reciprocal DBs
     if not client.is_reciprocal:
         params = copy.deepcopy(basic_parameters)
         request = client.fetch(_assemble_url('greens', **params))
@@ -138,7 +138,7 @@ def test_greens_retrieval(all_clients):
 
     db = instaseis.open_db(client.filepath)
 
-    # get_greens_seiscomp() only works with reciprocal DBs.
+    # get_greens_function() only works with reciprocal DBs.
     if not client.is_reciprocal:
         return
 
@@ -161,9 +161,10 @@ def test_greens_retrieval(all_clients):
     for tr in st_server:
         assert tr.stats._format == "SAC"
 
-    st_db = db.get_greens_seiscomp(
+    st_db = db.get_greens_function(
         epicentral_distance_in_degree=params['sourcedistanceindegrees'],
-        source_depth_in_m=params['sourcedepthinmeters'], origin_time=time)
+        source_depth_in_m=params['sourcedepthinmeters'], origin_time=time,
+        definition="seiscomp")
 
     for tr_server, tr_db in zip(st_server, st_db):
         # Remove the additional stats from both.
@@ -186,9 +187,10 @@ def test_greens_retrieval(all_clients):
     request = client.fetch(_assemble_url('greens', **params))
     st_server = obspy.read(request.buffer)
 
-    st_db = db.get_greens_seiscomp(
+    st_db = db.get_greens_function(
         epicentral_distance_in_degree=params['sourcedistanceindegrees'],
-        source_depth_in_m=params['sourcedepthinmeters'], origin_time=time)
+        source_depth_in_m=params['sourcedepthinmeters'], origin_time=time,
+        definition="seiscomp")
 
     for tr_server, tr_db in zip(st_server, st_db):
         # Remove the additional stats from both.

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -101,7 +101,7 @@ def test_greens_error_handling(all_clients):
 
     basic_parameters = {
         "sourcedepthinmeters": client.source_depth,
-        "sourcedistanceindegree": 20}
+        "sourcedistanceindegrees": 20}
 
     # get_greens_seiscomp() only works with reciprocal DBs. So make sure we get
     # the error, but then do the other tests only for reciprocal DBs
@@ -112,13 +112,13 @@ def test_greens_error_handling(all_clients):
         assert "the database is not reciprocal" in request.reason.lower()
         return
 
-    # Remove the sourcedistanceindegree, required parameter.
+    # Remove the sourcedistanceindegrees, required parameter.
     params = copy.deepcopy(basic_parameters)
-    del params["sourcedistanceindegree"]
+    del params["sourcedistanceindegrees"]
     request = client.fetch(_assemble_url('greens', **params))
     assert request.code == 400
     assert request.reason == \
-        "Required parameter 'sourcedistanceindegree' not given."
+        "Required parameter 'sourcedistanceindegrees' not given."
 
     # Remove the sourcedepthinmeters, required parameter.
     params = copy.deepcopy(basic_parameters)
@@ -144,7 +144,7 @@ def test_greens_retrieval(all_clients):
 
     basic_parameters = {
         "sourcedepthinmeters": 1e3,
-        "sourcedistanceindegree": 20,
+        "sourcedistanceindegrees": 20,
         "format": "saczip"}
 
     time = obspy.UTCDateTime(2010, 1, 2, 3, 4, 5)
@@ -162,7 +162,7 @@ def test_greens_retrieval(all_clients):
         assert tr.stats._format == "SAC"
 
     st_db = db.get_greens_seiscomp(
-        epicentral_distance_degree=params['sourcedistanceindegree'],
+        epicentral_distance_in_degree=params['sourcedistanceindegrees'],
         source_depth_in_m=params['sourcedepthinmeters'], origin_time=time)
 
     for tr_server, tr_db in zip(st_server, st_db):
@@ -187,7 +187,7 @@ def test_greens_retrieval(all_clients):
     st_server = obspy.read(request.buffer)
 
     st_db = db.get_greens_seiscomp(
-        epicentral_distance_degree=params['sourcedistanceindegree'],
+        epicentral_distance_in_degree=params['sourcedistanceindegrees'],
         source_depth_in_m=params['sourcedepthinmeters'], origin_time=time)
 
     for tr_server, tr_db in zip(st_server, st_db):

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -30,29 +30,11 @@ else:
     import unittest.mock as mock
 
 
-def _assemble_url(**kwargs):
+def _assemble_url(route, **kwargs):
     """
     Helper function.
     """
-    url = "/seismograms?"
-    url += "&".join("%s=%s" % (key, value) for key, value in kwargs.items())
-    return url
-
-
-def _assemble_url_raw(**kwargs):
-    """
-    Helper function.
-    """
-    url = "/seismograms_raw?"
-    url += "&".join("%s=%s" % (key, value) for key, value in kwargs.items())
-    return url
-
-
-def _assemble_url_greens(**kwargs):
-    """
-    Helper function.
-    """
-    url = "/greens?"
+    url = "/%s?" % route
     url += "&".join("%s=%s" % (key, value) for key, value in kwargs.items())
     return url
 
@@ -125,7 +107,7 @@ def test_greens_error_handling(all_clients):
     # the error, but then do the other tests only for reciprocal DBs
     if not client.is_reciprocal:
         params = copy.deepcopy(basic_parameters)
-        request = client.fetch(_assemble_url_greens(**params))
+        request = client.fetch(_assemble_url('greens', **params))
         assert request.code == 400
         assert "the database is not reciprocal" in request.reason.lower()
         return
@@ -133,7 +115,7 @@ def test_greens_error_handling(all_clients):
     # Remove the sourcedistanceindegree, required parameter.
     params = copy.deepcopy(basic_parameters)
     del params["sourcedistanceindegree"]
-    request = client.fetch(_assemble_url_greens(**params))
+    request = client.fetch(_assemble_url('greens', **params))
     assert request.code == 400
     assert request.reason == \
         "Required parameter 'sourcedistanceindegree' not given."
@@ -141,7 +123,7 @@ def test_greens_error_handling(all_clients):
     # Remove the sourcedepthinmeters, required parameter.
     params = copy.deepcopy(basic_parameters)
     del params["sourcedepthinmeters"]
-    request = client.fetch(_assemble_url_greens(**params))
+    request = client.fetch(_assemble_url('greens', **params))
     assert request.code == 400
     assert request.reason == \
         "Required parameter 'sourcedepthinmeters' not given."
@@ -169,7 +151,7 @@ def test_greens_retrieval(all_clients):
 
     # default parameters
     params = copy.deepcopy(basic_parameters)
-    request = client.fetch(_assemble_url_greens(**params))
+    request = client.fetch(_assemble_url('greens', **params))
     st_server = obspy.read(request.buffer)
 
     st_db = db.get_greens_seiscomp(
@@ -208,7 +190,7 @@ def test_raw_seismograms_error_handling(all_clients):
     # Remove the source latitude, a required parameter.
     params = copy.deepcopy(basic_parameters)
     del params["sourcelatitude"]
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert request.reason == \
         "Required parameter 'sourcelatitude' not given."
@@ -216,13 +198,14 @@ def test_raw_seismograms_error_handling(all_clients):
     # Invalid type.
     params = copy.deepcopy(basic_parameters)
     params["sourcelatitude"] = "A"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "could not be converted" in request.reason
     assert "sourcelatitude" in request.reason
 
     # No source.
-    request = client.fetch(_assemble_url_raw(**basic_parameters))
+    request = client.fetch(_assemble_url('seismograms_raw',
+                           **basic_parameters))
     assert request.code == 400
     assert request.reason == "No/insufficient source parameters specified"
 
@@ -235,7 +218,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["mrt"] = "100000"
     params["mrp"] = "100000"
     params["mtp"] = "100000"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "could not construct receiver with " in request.reason.lower()
 
@@ -248,7 +231,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["mrp"] = "100000"
     params["mtp"] = "100000"
     params["sourcelatitude"] = "100"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "could not construct moment tensor source" in request.reason.lower()
 
@@ -259,7 +242,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["rake"] = "45"
     params["M0"] = "450000"
     params["sourcelatitude"] = "100"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "could not construct the source" in request.reason.lower()
     assert "strike/dip/rake" in request.reason.lower()
@@ -271,7 +254,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["ft"] = "100000"
     params["fp"] = "100000"
     params["sourcelatitude"] = "100"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "could not construct force source" in request.reason.lower()
 
@@ -284,7 +267,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["mrp"] = "100000"
     params["mtp"] = "100000"
     params["components"] = "ABC"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "could not extract seismogram" in request.reason.lower()
 
@@ -300,7 +283,7 @@ def test_raw_seismograms_error_handling(all_clients):
         params["mrt"] = "100000"
         params["mrp"] = "100000"
         params["mtp"] = "100000"
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 500
         assert "could not convert seismogram to a" in request.reason.lower()
 
@@ -313,7 +296,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["mrp"] = "100000"
     params["mtp"] = "100000"
     params["components"] = "NNEERRTTZZ"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "a maximum of 5 components can be request" in request.reason.lower()
 
@@ -326,7 +309,7 @@ def test_raw_seismograms_error_handling(all_clients):
     params["mrp"] = "100000"
     params["mtp"] = "100000"
     params["components"] = ""
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "a request with no components will not re" in request.reason.lower()
 
@@ -355,7 +338,7 @@ def test_seismograms_raw_route(all_clients):
     # Moment tensor source.
     params = copy.deepcopy(basic_parameters)
     params.update(mt)
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 200
 
     st = obspy.read(request.buffer)
@@ -369,7 +352,7 @@ def test_seismograms_raw_route(all_clients):
     # Strike/dip/rake
     params = copy.deepcopy(basic_parameters)
     params.update(sdr)
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 200
 
     st = obspy.read(request.buffer)
@@ -386,7 +369,7 @@ def test_seismograms_raw_route(all_clients):
         params.update(fs)
         time = obspy.UTCDateTime(2008, 7, 6, 5, 4, 3)
         params["origintime"] = str(time)
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 200
 
         st = obspy.read(request.buffer)
@@ -404,7 +387,7 @@ def test_seismograms_raw_route(all_clients):
         params = copy.deepcopy(basic_parameters)
         params.update(mt)
         params["components"] = comp
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 200
 
         st = obspy.read(request.buffer)
@@ -417,7 +400,7 @@ def test_seismograms_raw_route(all_clients):
     time = obspy.UTCDateTime(2013, 1, 2, 3, 4, 5)
     params.update(mt)
     params["origintime"] = str(time)
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 200
 
     st = obspy.read(request.buffer)
@@ -430,7 +413,7 @@ def test_seismograms_raw_route(all_clients):
     params.update(mt)
     params["networkcode"] = "BW"
     params["stationcode"] = "ALTM"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 200
 
     st = obspy.read(request.buffer)
@@ -453,7 +436,7 @@ def test_mu_is_passed_as_header_value(all_clients):
                   "mrt": "100000", "mrp": "100000", "mtp": "100000"}
 
     # Moment tensor source.
-    request = client.fetch(_assemble_url_raw(**parameters))
+    request = client.fetch(_assemble_url('seismograms_raw', **parameters))
     assert request.code == 200
     # Make sure the mu header exists and the value can be converted to a float.
     assert "Instaseis-Mu" in request.headers
@@ -499,7 +482,7 @@ def test_object_creation_for_raw_seismogram_route(all_clients):
         # Moment tensor source.
         params = copy.deepcopy(basic_parameters)
         params.update(mt)
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -524,7 +507,7 @@ def test_object_creation_for_raw_seismogram_route(all_clients):
         params["networkcode"] = "BW"
         params["stationcode"] = "ALTM"
 
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -545,7 +528,7 @@ def test_object_creation_for_raw_seismogram_route(all_clients):
 
         params = copy.deepcopy(basic_parameters)
         params.update(sdr)
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -570,7 +553,7 @@ def test_object_creation_for_raw_seismogram_route(all_clients):
         params["networkcode"] = "BW"
         params["stationcode"] = "ALTM"
 
-        request = client.fetch(_assemble_url_raw(**params))
+        request = client.fetch(_assemble_url('seismograms_raw', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -592,7 +575,7 @@ def test_object_creation_for_raw_seismogram_route(all_clients):
 
             params = copy.deepcopy(basic_parameters)
             params.update(fs)
-            request = client.fetch(_assemble_url_raw(**params))
+            request = client.fetch(_assemble_url('seismograms_raw', **params))
             assert request.code == 200
 
             assert p.call_count == 1
@@ -617,7 +600,7 @@ def test_object_creation_for_raw_seismogram_route(all_clients):
             params["networkcode"] = "BW"
             params["stationcode"] = "ALTM"
 
-            request = client.fetch(_assemble_url_raw(**params))
+            request = client.fetch(_assemble_url('seismograms_raw', **params))
             assert request.code == 200
 
             assert p.call_count == 1
@@ -651,7 +634,7 @@ def test_seismograms_error_handling(all_clients):
     # Remove the source latitude, a required parameter.
     params = copy.deepcopy(basic_parameters)
     del params["sourcelatitude"]
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == \
         "The following required parameters are missing: 'sourcelatitude'"
@@ -659,13 +642,13 @@ def test_seismograms_error_handling(all_clients):
     # Invalid type.
     params = copy.deepcopy(basic_parameters)
     params["sourcelatitude"] = "A"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "could not be converted" in request.reason
     assert "sourcelatitude" in request.reason
 
     # No source.
-    request = client.fetch(_assemble_url(**basic_parameters))
+    request = client.fetch(_assemble_url('seismograms', **basic_parameters))
     assert request.code == 400
     assert request.reason == (
         "One of the following has to be given: 'eventid', "
@@ -675,7 +658,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["receiverlatitude"] = "100"
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "could not construct receiver with " in request.reason.lower()
 
@@ -683,7 +666,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["sourcelatitude"] = "100"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "could not construct moment tensor source" in request.reason.lower()
 
@@ -691,7 +674,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcedoublecouple"] = "45,45,45,450000"
     params["sourcelatitude"] = "100"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "could not construct the source" in request.reason.lower()
     assert "strike/dip/rake" in request.reason.lower()
@@ -701,7 +684,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourceforce"] = "100000,100000,100000"
     params["sourcelatitude"] = "100"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "could not construct force source" in request.reason.lower()
 
@@ -709,7 +692,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["components"] = "ABC"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "could not extract seismogram" in request.reason.lower()
 
@@ -717,7 +700,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["units"] = "fun"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "unit must be one of" in request.reason.lower()
 
@@ -726,7 +709,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["dt"] = "0.009"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "the smallest possible dt is 0.01" in request.reason.lower()
 
@@ -734,13 +717,13 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["kernelwidth"] = "0"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "`kernelwidth` must not be smaller" in request.reason.lower()
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["kernelwidth"] = "21"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "`kernelwidth` must not be smaller" in request.reason.lower()
 
@@ -748,7 +731,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["components"] = "NNEERRTTZZ"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "a maximum of 5 components can be request" in request.reason.lower()
 
@@ -756,7 +739,7 @@ def test_seismograms_error_handling(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = "100000,100000,100000,100000,100000,100000"
     params["components"] = ""
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "a request with no components will not re" in request.reason.lower()
 
@@ -798,7 +781,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         # Moment tensor source.
         params = copy.deepcopy(basic_parameters)
         params["sourcemomenttensor"] = mt_param
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -841,7 +824,7 @@ def test_object_creation_for_seismogram_route(all_clients):
             tr.stats.starttime = time - 1 - 7 * dt
             tr.stats.delta = dt
 
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -874,7 +857,7 @@ def test_object_creation_for_seismogram_route(all_clients):
 
         params = copy.deepcopy(basic_parameters)
         params["sourcedoublecouple"] = sdr_param
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -914,7 +897,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params["networkcode"] = "BW"
         params["stationcode"] = "ALTM"
 
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -947,7 +930,7 @@ def test_object_creation_for_seismogram_route(all_clients):
 
         params = copy.deepcopy(basic_parameters)
         params["sourcedoublecouple"] = "10,10,10"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
 
         assert p.call_count == 1
@@ -979,7 +962,7 @@ def test_object_creation_for_seismogram_route(all_clients):
 
             params = copy.deepcopy(basic_parameters)
             params["sourceforce"] = fs_param
-            request = client.fetch(_assemble_url(**params))
+            request = client.fetch(_assemble_url('seismograms', **params))
             assert request.code == 200
 
             assert p.call_count == 1
@@ -1014,7 +997,7 @@ def test_object_creation_for_seismogram_route(all_clients):
             params["networkcode"] = "BW"
             params["stationcode"] = "ALTM"
 
-            request = client.fetch(_assemble_url(**params))
+            request = client.fetch(_assemble_url('seismograms', **params))
             assert request.code == 200
 
             assert p.call_count == 1
@@ -1047,7 +1030,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params = copy.deepcopy(basic_parameters)
         params["sourcemomenttensor"] = mt_param
         params["components"] = "RTE"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert p.call_count == 1
         assert p.call_args[1]["components"] == ["R", "T", "E"]
@@ -1062,7 +1045,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params = copy.deepcopy(basic_parameters)
         params["sourcemomenttensor"] = mt_param
         params["units"] = "acceleration"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert p.call_count == 1
         assert p.call_args[1]["components"] == ["Z", "N", "E"]
@@ -1077,7 +1060,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params = copy.deepcopy(basic_parameters)
         params["sourcemomenttensor"] = mt_param
         params["units"] = "velocity"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert p.call_count == 1
         assert p.call_args[1]["components"] == ["Z", "N", "E"]
@@ -1092,7 +1075,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params = copy.deepcopy(basic_parameters)
         params["sourcemomenttensor"] = mt_param
         params["units"] = "VeLoCity"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert p.call_count == 1
         assert p.call_args[1]["components"] == ["Z", "N", "E"]
@@ -1108,7 +1091,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params["sourcemomenttensor"] = mt_param
         params["dt"] = "0.1"
         params["kernelwidth"] = "20"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert p.call_count == 1
         assert p.call_args[1]["components"] == ["Z", "N", "E"]
@@ -1130,7 +1113,7 @@ def test_object_creation_for_seismogram_route(all_clients):
         params["dt"] = "0.1"
         params["kernelwidth"] = "2"
         params["units"] = "ACCELERATION"
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert p.call_count == 1
         assert p.call_args[1]["components"] == ["Z", "N", "E"]
@@ -1173,7 +1156,7 @@ def test_seismograms_retrieval(all_clients):
     # Moment tensor source.
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = mt_param
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
 
     components = ["Z", "N", "E"]
@@ -1215,7 +1198,7 @@ def test_seismograms_retrieval(all_clients):
     params["origintime"] = str(time)
     params["networkcode"] = "BW"
     params["stationcode"] = "ALTM"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
 
     source = instaseis.Source(
@@ -1250,7 +1233,7 @@ def test_seismograms_retrieval(all_clients):
     # From strike, dip, rake
     params = copy.deepcopy(basic_parameters)
     params["sourcedoublecouple"] = sdr_param
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
 
     source = instaseis.Source.from_strike_dip_rake(
@@ -1291,7 +1274,7 @@ def test_seismograms_retrieval(all_clients):
     params["networkcode"] = "BW"
     params["stationcode"] = "ALTM"
 
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
 
     source = instaseis.Source.from_strike_dip_rake(
@@ -1326,7 +1309,7 @@ def test_seismograms_retrieval(all_clients):
     if "displ_only" in client.filepath:
         params = copy.deepcopy(basic_parameters)
         params["sourceforce"] = fs_param
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         st_server = obspy.read(request.buffer)
 
         source = instaseis.ForceSource(
@@ -1368,7 +1351,7 @@ def test_seismograms_retrieval(all_clients):
         params["networkcode"] = "BW"
         params["stationcode"] = "ALTM"
 
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         st_server = obspy.read(request.buffer)
 
         source = instaseis.ForceSource(
@@ -1416,7 +1399,7 @@ def test_seismograms_retrieval(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = mt_param
     params["components"] = "RTE"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
     st_db = db.get_seismograms(source=source, receiver=receiver,
                                components=["R", "T", "E"])
@@ -1439,7 +1422,7 @@ def test_seismograms_retrieval(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = mt_param
     params["units"] = "acceleration"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
     st_db = db.get_seismograms(source=source, receiver=receiver,
                                kind="acceleration")
@@ -1462,7 +1445,7 @@ def test_seismograms_retrieval(all_clients):
     params = copy.deepcopy(basic_parameters)
     params["sourcemomenttensor"] = mt_param
     params["units"] = "velocity"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
     st_db = db.get_seismograms(source=source, receiver=receiver,
                                kind="velocity")
@@ -1486,7 +1469,7 @@ def test_seismograms_retrieval(all_clients):
     params["sourcemomenttensor"] = mt_param
     params["dt"] = "0.1"
     params["kernelwidth"] = "1"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
     st_db = db.get_seismograms(source=source, receiver=receiver,
                                dt=0.1, kernelwidth=1)
@@ -1512,7 +1495,7 @@ def test_seismograms_retrieval(all_clients):
     params["dt"] = "0.1"
     params["kernelwidth"] = "2"
     params["units"] = "ACCELERATION"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st_server = obspy.read(request.buffer)
     st_db = db.get_seismograms(source=source, receiver=receiver,
                                dt=0.1, kernelwidth=2, kind="acceleration",
@@ -1552,7 +1535,7 @@ def test_output_formats(all_clients):
     # First try to get a MiniSEED file.
     params = copy.deepcopy(basic_parameters)
     params["format"] = "miniseed"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st = obspy.read(request.buffer)
     for tr in st:
         assert tr.stats._format == "MSEED"
@@ -1560,7 +1543,7 @@ def test_output_formats(all_clients):
     # saczip results in a folder of multiple sac files.
     params = copy.deepcopy(basic_parameters)
     params["format"] = "saczip"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     # ObsPy needs the filename to be able to directly unpack zip files. We
     # don't have a filename here so we unpack manually.
     sac_st = obspy.Stream()
@@ -1598,7 +1581,7 @@ def test_output_formats(all_clients):
     # Specifying the saczip format also work.
     params = copy.deepcopy(basic_parameters)
     params["format"] = "saczip"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     sac_st = obspy.Stream()
     zip_obj = zipfile.ZipFile(request.buffer)
     for name in zip_obj.namelist():
@@ -1621,7 +1604,7 @@ def test_output_formats(all_clients):
     # First get a MiniSEED file.
     params = copy.deepcopy(basic_parameters)
     params["format"] = "miniseed"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     st = obspy.read(request.buffer)
     for tr in st:
         assert tr.stats._format == "MSEED"
@@ -1629,7 +1612,7 @@ def test_output_formats(all_clients):
     # saczip results in a folder of multiple sac files.
     params = copy.deepcopy(basic_parameters)
     params["format"] = "saczip"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     # ObsPy needs the filename to be able to directly unpack zip files. We
     # don't have a filename here so we unpack manually.
     sac_st = obspy.Stream()
@@ -1667,7 +1650,7 @@ def test_output_formats(all_clients):
     # Specifying the saczip format also work.
     params = copy.deepcopy(basic_parameters)
     params["format"] = "saczip"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     sac_st = obspy.Stream()
     zip_obj = zipfile.ZipFile(request.buffer)
     for name in zip_obj.namelist():
@@ -1777,7 +1760,7 @@ def test_cors_headers(all_clients_all_callbacks):
         "mrt": "100000",
         "mrp": "100000",
         "mtp": "100000"}
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 200
     assert "Access-Control-Allow-Origin" in request.headers
     assert request.headers["Access-Control-Allow-Origin"] == "*"
@@ -1790,7 +1773,7 @@ def test_cors_headers(all_clients_all_callbacks):
         "receiverlatitude": -10,
         "receiverlongitude": -10,
         "sourcemomenttensor": "100000,100000,100000,100000,100000,100000"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert "Access-Control-Allow-Origin" in request.headers
     assert request.headers["Access-Control-Allow-Origin"] == "*"
@@ -1819,13 +1802,13 @@ def test_cors_headers_failing_requests(all_clients_all_callbacks):
 
     # raw seismograms route
     params = {}
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert "Access-Control-Allow-Origin" in request.headers
     assert request.headers["Access-Control-Allow-Origin"] == "*"
 
     # standard seismograms route
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert "Access-Control-Allow-Origin" in request.headers
     assert request.headers["Access-Control-Allow-Origin"] == "*"
@@ -1862,7 +1845,7 @@ def test_multiple_seismograms_retrieval_no_format_given(
     params["station"] = "ANT*,ANM?"
 
     # Default format is MiniSEED>
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/zip"
     st_server = obspy.Stream()
@@ -1920,7 +1903,7 @@ def test_multiple_seismograms_retrieval_no_format_given(
     params["origintime"] = str(time)
 
     # Default format is MiniSEED>
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/zip"
     st_server = obspy.Stream()
@@ -1976,7 +1959,7 @@ def test_multiple_seismograms_retrieval_no_format_given(
         params["components"] = "NEZRT"
 
         # Default format is MiniSEED>
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert request.headers["Content-Type"] == "application/zip"
         st_server = obspy.Stream()
@@ -2057,7 +2040,7 @@ def test_multiple_seismograms_retrieval_no_format_given_single_station(
     params["station"] = "ANMO"
 
     # Default format is saczip.
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/zip"
     st_server = obspy.Stream()
@@ -2115,7 +2098,7 @@ def test_multiple_seismograms_retrieval_no_format_given_single_station(
     params["origintime"] = str(time)
 
     # Default format is MiniSEED>
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/zip"
     st_server = obspy.Stream()
@@ -2169,7 +2152,7 @@ def test_multiple_seismograms_retrieval_no_format_given_single_station(
         params["components"] = "NEZRT"
 
         # Default format is MiniSEED>
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert request.headers["Content-Type"] == "application/zip"
         st_server = obspy.Stream()
@@ -2246,7 +2229,7 @@ def test_multiple_seismograms_retrieval_mseed_format(
     params["station"] = "ANT*,ANM?"
 
     # Default format is MiniSEED>
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/octet-stream"
     st_server = obspy.read(request.buffer)
@@ -2304,7 +2287,7 @@ def test_multiple_seismograms_retrieval_mseed_format(
         params["sourcedepthinmeters"] = str(client.source_depth)
 
     # Default format is MiniSEED>
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/octet-stream"
     st_server = obspy.read(request.buffer)
@@ -2358,7 +2341,7 @@ def test_multiple_seismograms_retrieval_mseed_format(
         params["components"] = "NEZRT"
 
         # Default format is MiniSEED>
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert request.headers["Content-Type"] == "application/octet-stream"
         st_server = obspy.read(request.buffer)
@@ -2436,7 +2419,7 @@ def test_multiple_seismograms_retrieval_saczip_format(
     params["station"] = "ANT*,ANM?"
 
     # Default format is MiniSEED>
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/zip"
 
@@ -2501,7 +2484,7 @@ def test_multiple_seismograms_retrieval_saczip_format(
         params["sourcedepthinmeters"] = str(client.source_depth)
 
     # Default format is saczip.
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     assert request.headers["Content-Type"] == "application/zip"
 
@@ -2561,7 +2544,7 @@ def test_multiple_seismograms_retrieval_saczip_format(
         params["components"] = "NEZRT"
 
         # Default format is MiniSEED>
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 200
         assert request.headers["Content-Type"] == "application/zip"
 
@@ -2628,7 +2611,7 @@ def test_multiple_seismograms_retrieval_invalid_format(
     params["network"] = "IU,B*"
     params["station"] = "ANT*,ANM?"
 
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == "Format must either be 'miniseed' or 'saczip'."
 
@@ -2648,7 +2631,7 @@ def test_multiple_seismograms_retrieval_no_stations(
     params["network"] = "HE"
     params["station"] = "LLO"
 
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 404
     assert request.reason == "No coordinates found satisfying the query."
 
@@ -2664,13 +2647,13 @@ def test_unknown_parameter_raises(all_clients):
         "sourcelatitude": 10, "sourcelongitude": 10, "receiverlatitude": -10,
         "receiverlongitude": -10, "mtt": "100000", "mpp": "100000",
         "mrr": "100000", "mrt": "100000", "mrp": "100000", "mtp": "100000"}
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 200
 
     # Adding a random other parameter raises
     params["bogus"] = "bogus"
     params["random"] = "stuff"
-    request = client.fetch(_assemble_url_raw(**params))
+    request = client.fetch(_assemble_url('seismograms_raw', **params))
     assert request.code == 400
     assert request.reason == ("The following unknown parameters have been "
                               "passed: 'bogus', 'random'")
@@ -2680,13 +2663,13 @@ def test_unknown_parameter_raises(all_clients):
         "sourcelatitude": 10, "sourcelongitude": 10, "receiverlatitude": -10,
         "receiverlongitude": -10, "sourcedepthinmeters": client.source_depth,
         "sourcemomenttensor": "100000,100000,100000,100000,100000,100000"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
 
     # Adding a random other parameter raises
     params["random"] = "stuff"
     params["bogus"] = "bogus"
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == ("The following unknown parameters have been "
                               "passed: 'bogus', 'random'")
@@ -2704,7 +2687,7 @@ def test_passing_duplicate_parameter_raises(all_clients):
         "sourcelatitude": 10, "sourcelongitude": 10, "receiverlatitude": -10,
         "receiverlongitude": -10, "mtt": "100000", "mpp": "100000",
         "mrr": "100000", "mrt": "100000", "mrp": "100000", "mtp": "100000"}
-    url = _assemble_url_raw(**params)
+    url = _assemble_url('seismograms_raw', **params)
     request = client.fetch(url)
     assert request.code == 200
 
@@ -2720,7 +2703,7 @@ def test_passing_duplicate_parameter_raises(all_clients):
         "sourcelatitude": 10, "sourcelongitude": 10, "receiverlatitude": -10,
         "receiverlongitude": -10, "sourcedepthinmeters": client.source_depth,
         "sourcemomenttensor": "100000,100000,100000,100000,100000,100000"}
-    url = _assemble_url(**params)
+    url = _assemble_url('seismograms', **params)
     request = client.fetch(url)
     assert request.code == 200
 
@@ -2745,14 +2728,14 @@ def test_passing_invalid_time_settings_raises(all_clients):
         "origintime": str(origin_time)}
 
     # This should work fine.
-    url = _assemble_url(**params)
+    url = _assemble_url('seismograms', **params)
     request = client.fetch(url)
     assert request.code == 200
 
     # The remainder should not.
     p = copy.deepcopy(params)
     p["starttime"] = str(origin_time + 1E6)
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     assert request.code == 400
     assert request.reason == ("The `starttime` must be before the seismogram "
@@ -2760,7 +2743,7 @@ def test_passing_invalid_time_settings_raises(all_clients):
 
     p = copy.deepcopy(params)
     p["endtime"] = str(origin_time - 1E6)
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     assert request.code == 400
     assert request.reason == ("The end time of the seismograms lies outside "
@@ -2768,7 +2751,7 @@ def test_passing_invalid_time_settings_raises(all_clients):
 
     p = copy.deepcopy(params)
     p["starttime"] = str(origin_time - 3800)
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     assert request.code == 400
     assert request.reason == ("The seismogram can start at the maximum one "
@@ -2793,7 +2776,7 @@ def test_time_settings_for_seismograms_route(all_clients):
         "format": "miniseed"}
 
     p = copy.deepcopy(params)
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st = obspy.read(request.buffer)
 
@@ -2804,7 +2787,7 @@ def test_time_settings_for_seismograms_route(all_clients):
     # Different starttime.
     p = copy.deepcopy(params)
     p["starttime"] = origin_time - 10
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st_2 = obspy.read(request.buffer)
 
@@ -2815,7 +2798,7 @@ def test_time_settings_for_seismograms_route(all_clients):
     # an offset to the origin time.
     p = copy.deepcopy(params)
     p["starttime"] = -10
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st_2 = obspy.read(request.buffer)
 
@@ -2835,7 +2818,7 @@ def test_time_settings_for_seismograms_route(all_clients):
     # Test endtime settings.
     p = copy.deepcopy(params)
     p["endtime"] = origin_time + 10
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st_2 = obspy.read(request.buffer)
 
@@ -2847,7 +2830,7 @@ def test_time_settings_for_seismograms_route(all_clients):
     # offset in respect to the starttime.
     p = copy.deepcopy(params)
     p["endtime"] = 13.0
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st_2 = obspy.read(request.buffer)
 
@@ -2859,7 +2842,7 @@ def test_time_settings_for_seismograms_route(all_clients):
     p = copy.deepcopy(params)
     p["endtime"] = 10
     p["starttime"] = origin_time - 5
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st_2 = obspy.read(request.buffer)
 
@@ -2871,7 +2854,7 @@ def test_time_settings_for_seismograms_route(all_clients):
     # in the back will raise an error but that is tested elsewhere.
     p = copy.deepcopy(params)
     p["starttime"] = origin_time - 1800
-    url = _assemble_url(**p)
+    url = _assemble_url('seismograms', **p)
     request = client.fetch(url)
     st_2 = obspy.read(request.buffer)
 
@@ -2944,7 +2927,7 @@ def test_station_query_various_failures(
     p["station"] = "ANT*,ANM?"
     p["receiverlatitude"] = 1.0
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == (
         "Receiver coordinates can either be specified by passing "
@@ -2955,7 +2938,7 @@ def test_station_query_various_failures(
     p = copy.deepcopy(params)
     p["network"] = "IU,B*"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == (
         "Must specify a full set of coordinates or a full set of receiver "
@@ -2966,7 +2949,7 @@ def test_station_query_various_failures(
     p["network"] = "X*"
     p["station"] = "Y*"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 404
     assert request.reason == ("No coordinates found satisfying the query.")
 
@@ -2985,7 +2968,7 @@ def test_station_query_no_callback(all_clients):
     p["network"] = "IU,B*"
     p["station"] = "ANT*,ANM?"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 404
     assert request.reason == (
         "Server does not support station coordinates and thus no station "
@@ -3003,7 +2986,7 @@ def test_event_query_no_callbacks(all_clients):
     p = copy.deepcopy(params)
     p["eventid"] = "B071791B"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 404
     assert request.reason == (
         "Server does not support event information and thus no event queries.")
@@ -3025,7 +3008,7 @@ def test_event_query_various_failures(all_clients_event_callback):
     p["sourcedepthinmeters"] = -20
 
     # Cannot not pass other source parameters along.
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == (
         "The following parameters cannot be used if 'eventid' is a "
@@ -3038,7 +3021,7 @@ def test_event_query_various_failures(all_clients_event_callback):
     p["origintime"] = obspy.UTCDateTime(2014, 1, 1)
 
     # Cannot not pass other source parameters along.
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == (
         "'eventid' and 'origintime' parameters cannot both be passed at the "
@@ -3063,7 +3046,7 @@ def test_event_parameters_by_querying(all_clients_event_callback):
     p = copy.deepcopy(params)
     p["eventid"] = "B071791B"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     st = obspy.read(request.buffer)
 
@@ -3103,7 +3086,7 @@ def test_event_parameters_by_querying(all_clients_event_callback):
             tr.stats.starttime = source.origin_time - 0.01
             tr.stats.delta = 10.0
         patch.return_value = _st
-        result = client.fetch(_assemble_url(**p))
+        result = client.fetch(_assemble_url('seismograms', **p))
         assert result.code == 200
 
     assert patch.call_args[1]["source"] == source
@@ -3117,7 +3100,7 @@ def test_event_query_seismogram_non_existent_event(all_clients_event_callback):
 
     params = {"receiverlatitude": 10, "receiverlongitude": 10,
               "eventid": "bogus"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 404
     assert request.reason == "Event not found."
 
@@ -3138,7 +3121,7 @@ def test_label_parameter(all_clients):
     # No specified label will result in it having a generic label.
     p = copy.deepcopy(params)
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
 
     filename = request.headers["Content-Disposition"]
@@ -3153,7 +3136,7 @@ def test_label_parameter(all_clients):
     p = copy.deepcopy(params)
     p["format"] = "saczip"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
 
     filename = request.headers["Content-Disposition"]
@@ -3174,7 +3157,7 @@ def test_label_parameter(all_clients):
     p = copy.deepcopy(params)
     p["label"] = "Tohoku"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
 
     filename = request.headers["Content-Disposition"]
@@ -3189,7 +3172,7 @@ def test_label_parameter(all_clients):
     p["format"] = "saczip"
     p["label"] = "Tohoku"
 
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
 
     filename = request.headers["Content-Disposition"]
@@ -3317,7 +3300,7 @@ def test_network_and_station_code_settings(all_clients):
 
     # Default network and station codes.
     p = copy.deepcopy(params)
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     for tr in obspy.read(request.buffer):
         assert tr.stats.network == "XX"
@@ -3326,7 +3309,7 @@ def test_network_and_station_code_settings(all_clients):
     # Set only the network code.
     p = copy.deepcopy(params)
     p["networkcode"] = "BW"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     for tr in obspy.read(request.buffer):
         assert tr.stats.network == "BW"
@@ -3335,7 +3318,7 @@ def test_network_and_station_code_settings(all_clients):
     # Set only the station code.
     p = copy.deepcopy(params)
     p["stationcode"] = "INS"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     for tr in obspy.read(request.buffer):
         assert tr.stats.network == "XX"
@@ -3345,7 +3328,7 @@ def test_network_and_station_code_settings(all_clients):
     p = copy.deepcopy(params)
     p["networkcode"] = "BW"
     p["stationcode"] = "INS"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     for tr in obspy.read(request.buffer):
         assert tr.stats.network == "BW"
@@ -3354,14 +3337,14 @@ def test_network_and_station_code_settings(all_clients):
     # Station code is limited to five letters.
     p = copy.deepcopy(params)
     p["stationcode"] = "123456"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == "'stationcode' must have 5 or fewer letters."
 
     # Network code is limited to two letters.
     p = copy.deepcopy(params)
     p["networkcode"] = "123"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == "'networkcode' must have 2 or fewer letters."
 
@@ -3394,7 +3377,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
 
     # Normal seismogram.
     p = copy.deepcopy(params)
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     starttime, endtime = tr.stats.starttime, tr.stats.endtime
@@ -3402,7 +3385,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     # Start 10 seconds before the P arrival.
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3412,7 +3395,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     # Starts 10 seconds after the P arrival
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3422,7 +3405,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     # Ends 15 seconds before the PP arrival
     p = copy.deepcopy(params)
     p["endtime"] = "PP%2D15"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3432,7 +3415,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     # Ends 15 seconds after the PP arrival
     p = copy.deepcopy(params)
     p["endtime"] = "PP%2B15"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3443,7 +3426,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     p = copy.deepcopy(params)
     p["starttime"] = "PP%2D5"
     p["endtime"] = "sPKiKP%2B2"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3456,7 +3439,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     p = copy.deepcopy(params)
     p["starttime"] = "PP%2D5"
     p["endtime"] = 10.0
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3468,7 +3451,7 @@ def test_phase_relative_offsets(all_clients_ttimes_callback):
     p = copy.deepcopy(params)
     p["starttime"] = "10"
     p["endtime"] = "PP%2B15"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
 
@@ -3490,7 +3473,7 @@ def test_phase_relative_offsets_but_no_ttimes_callback(all_clients):
     # Test for starttime.
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 404
     assert request.reason == (
         "Server does not support travel time calculations.")
@@ -3498,7 +3481,7 @@ def test_phase_relative_offsets_but_no_ttimes_callback(all_clients):
     # Test for endtime.
     p = copy.deepcopy(params)
     p["endtime"] = "P%2D10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 404
     assert request.reason == (
         "Server does not support travel time calculations.")
@@ -3507,7 +3490,7 @@ def test_phase_relative_offsets_but_no_ttimes_callback(all_clients):
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D10"
     p["endtime"] = "S%2B10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 404
     assert request.reason == (
         "Server does not support travel time calculations.")
@@ -3531,7 +3514,7 @@ def test_phase_relative_offset_different_time_representations(
 
     # Normal seismogram.
     p = copy.deepcopy(params)
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     starttime, endtime = tr.stats.starttime, tr.stats.endtime
@@ -3539,7 +3522,7 @@ def test_phase_relative_offset_different_time_representations(
     # P+10
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 - 10)) < 0.1
@@ -3548,7 +3531,7 @@ def test_phase_relative_offset_different_time_representations(
     # P-10
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 + 10)) < 0.1
@@ -3557,7 +3540,7 @@ def test_phase_relative_offset_different_time_representations(
     # P+10.0
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D10.0"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 - 10)) < 0.1
@@ -3566,7 +3549,7 @@ def test_phase_relative_offset_different_time_representations(
     # P-10.0
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B10.0"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 + 10)) < 0.1
@@ -3575,7 +3558,7 @@ def test_phase_relative_offset_different_time_representations(
     # P+10.000
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D10.000"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 - 10)) < 0.1
@@ -3584,7 +3567,7 @@ def test_phase_relative_offset_different_time_representations(
     # P-10.000
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B10.000"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 + 10)) < 0.1
@@ -3593,7 +3576,7 @@ def test_phase_relative_offset_different_time_representations(
     # P+1E1
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D1E1"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 - 10)) < 0.1
@@ -3602,7 +3585,7 @@ def test_phase_relative_offset_different_time_representations(
     # P-1E1
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B1E1"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 + 10)) < 0.1
@@ -3611,7 +3594,7 @@ def test_phase_relative_offset_different_time_representations(
     # P+1.0E1
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D1.0E1"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 - 10)) < 0.1
@@ -3620,7 +3603,7 @@ def test_phase_relative_offset_different_time_representations(
     # P-1.0E1
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B1.0E1"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 + 10)) < 0.1
@@ -3629,7 +3612,7 @@ def test_phase_relative_offset_different_time_representations(
     # P+1e1
     p = copy.deepcopy(params)
     p["starttime"] = "P%2D1e1"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 - 10)) < 0.1
@@ -3638,7 +3621,7 @@ def test_phase_relative_offset_different_time_representations(
     # P-1e1
     p = copy.deepcopy(params)
     p["starttime"] = "P%2B1e1"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 200
     tr = obspy.read(request.buffer)[0]
     assert abs((tr.stats.starttime) - (starttime + 504.357 + 10)) < 0.1
@@ -3662,14 +3645,14 @@ def test_phase_relative_offset_failures(all_clients_ttimes_callback):
     # Illegal phase.
     p = copy.deepcopy(params)
     p["starttime"] = "bogus%2D10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == "Invalid phase name: bogus"
 
     # Phase not available at that distance.
     p = copy.deepcopy(params)
     p["starttime"] = "Pdiff%2D10"
-    request = client.fetch(_assemble_url(**p))
+    request = client.fetch(_assemble_url('seismograms', **p))
     assert request.code == 400
     assert request.reason == (
         "No seismograms found for the given phase relative "
@@ -3696,7 +3679,7 @@ def test_phase_relative_offsets_multiple_stations(all_clients_all_callbacks):
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?",
         "starttime": "P%2D10"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     st = obspy.read(request.buffer)
     assert len(st) == 1
@@ -3710,7 +3693,7 @@ def test_phase_relative_offsets_multiple_stations(all_clients_all_callbacks):
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?",
         "endtime": "P%2D10"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     st = obspy.read(request.buffer)
     assert len(st) == 1
@@ -3723,7 +3706,7 @@ def test_phase_relative_offsets_multiple_stations(all_clients_all_callbacks):
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?",
         "starttime": "P%2D10"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     st = obspy.read(request.buffer)
     assert len(st) == 2
@@ -3736,7 +3719,7 @@ def test_phase_relative_offsets_multiple_stations(all_clients_all_callbacks):
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?",
         "starttime": "P%2D10000"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "No seismograms found for the given phase relative "
@@ -3753,7 +3736,7 @@ def test_phase_relative_offsets_multiple_stations(all_clients_all_callbacks):
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?",
         "endtime": "P%2B10000"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "No seismograms found for the given phase relative "
@@ -3773,7 +3756,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcedepthinmeters": 300000,
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "One of the following has to be given: 'eventid', "
@@ -3786,7 +3769,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcemomenttensor": "100000,100000,100000,100000,100000",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourcemomenttensor' must be formatted as: "
@@ -3799,7 +3782,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcemomenttensor": "100000,100000,100000,100000,100000,bogus",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourcemomenttensor' must be formatted as: "
@@ -3812,7 +3795,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcedoublecouple": "100000,100000",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourcedoublecouple' must be formatted as: "
@@ -3825,7 +3808,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcedoublecouple": "100000,100000,10,11,12",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourcedoublecouple' must be formatted as: "
@@ -3838,7 +3821,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcedoublecouple": "100000,100000,10,bogus",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourcedoublecouple' must be formatted as: "
@@ -3851,7 +3834,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourceforce": "100000,100000",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourceforce' must be formatted as: "
@@ -3864,7 +3847,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourceforce": "100000,100000,bogus",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'sourceforce' must be formatted as: "
@@ -3877,7 +3860,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourcedoublecouple": "100000,100000,10,-10",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == "Seismic moment must not be negative."
 
@@ -3889,7 +3872,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "components": "Z", "dt": 0.1,
         "starttime": "P+!A",
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Parameter 'starttime' must be formatted as: 'Datetime "
@@ -3903,7 +3886,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
         "sourceforce": "10,10,10",
         "components": "Z", "dt": 0.1,
         "format": "miniseed", "network": "IU,B*", "station": "ANT*,ANM?"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == ("Only one of these parameters can be given "
                               "simultaneously: 'sourcedoublecouple', "
@@ -3919,7 +3902,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
             "receiverdepthinmeters": 10,
             "components": "Z", "dt": 0.1,
             "format": "miniseed"}
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 400
         assert request.reason == ("Receiver must be at the surface for "
                                   "reciprocal databases.")
@@ -3932,7 +3915,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
             "receiverlatitude": 10, "receiverlongitude": 10,
             "components": "Z", "dt": 0.1,
             "format": "miniseed"}
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 400
         assert request.reason == ("Source depth must be within the database "
                                   "range: 0.0 - 371000.0 meters.")
@@ -3948,7 +3931,7 @@ def test_various_failure_conditions(all_clients_all_callbacks):
             "receiverdepthinmeters": 10,
             "components": "Z", "dt": 0.1,
             "format": "miniseed"}
-        request = client.fetch(_assemble_url(**params))
+        request = client.fetch(_assemble_url('seismograms', **params))
         assert request.code == 400
         assert request.reason == (
             "Source depth must be: %.1f km" % db.info.source_depth)
@@ -3966,7 +3949,7 @@ def test_sac_headers(all_clients):
         "sourcemomenttensor": "1E15,1E15,1E15,1E15,1E15,1E15",
         "dt": 0.1, "starttime": "-1.5", "receiverlatitude": 22,
         "receiverlongitude": 44, "format": "saczip"}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
     st = obspy.Stream()
     zip_obj = zipfile.ZipFile(request.buffer)
@@ -4004,7 +3987,7 @@ def test_dt_settings(all_clients):
         "sourcemomenttensor": "1E15,1E15,1E15,1E15,1E15,1E15",
         "dt": client.info.dt,
         "receiverlatitude": 22, "receiverlongitude": 44}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
 
     # Request exactly at 100 Hz works.
@@ -4014,7 +3997,7 @@ def test_dt_settings(all_clients):
         "sourcemomenttensor": "1E15,1E15,1E15,1E15,1E15,1E15",
         "dt": 0.01,
         "receiverlatitude": 22, "receiverlongitude": 44}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
 
     # Requesting at something in between works.
@@ -4024,7 +4007,7 @@ def test_dt_settings(all_clients):
         "sourcemomenttensor": "1E15,1E15,1E15,1E15,1E15,1E15",
         "dt": 0.123,
         "receiverlatitude": 22, "receiverlongitude": 44}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 200
 
     # Requesting a tiny bit above does not work.
@@ -4034,7 +4017,7 @@ def test_dt_settings(all_clients):
         "sourcemomenttensor": "1E15,1E15,1E15,1E15,1E15,1E15",
         "dt": 0.009,
         "receiverlatitude": 22, "receiverlongitude": 44}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "The smallest possible dt is 0.01. Please choose a smaller value and "
@@ -4047,7 +4030,7 @@ def test_dt_settings(all_clients):
         "sourcemomenttensor": "1E15,1E15,1E15,1E15,1E15,1E15",
         "dt": client.info.dt + 0.001,
         "receiverlatitude": 22, "receiverlongitude": 44}
-    request = client.fetch(_assemble_url(**params))
+    request = client.fetch(_assemble_url('seismograms', **params))
     assert request.code == 400
     assert request.reason == (
         "Cannot downsample. The sampling interval of the database is "

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -93,9 +93,9 @@ def test_info_route(all_clients):
     np.testing.assert_allclose(client_sliprate, db_sliprate)
 
 
-def test_greens_error_handling(all_clients):
+def test_greens_function_error_handling(all_clients):
     """
-    Tests error handling of the /greens route. Very basic for now
+    Tests error handling of the /greens_function route. Very basic for now
     """
     client = all_clients
 
@@ -107,7 +107,7 @@ def test_greens_error_handling(all_clients):
     # get the error, but then do the other tests only for reciprocal DBs
     if not client.is_reciprocal:
         params = copy.deepcopy(basic_parameters)
-        request = client.fetch(_assemble_url('greens', **params))
+        request = client.fetch(_assemble_url('greens_function', **params))
         assert request.code == 400
         assert "the database is not reciprocal" in request.reason.lower()
         return
@@ -115,7 +115,7 @@ def test_greens_error_handling(all_clients):
     # Remove the sourcedistanceindegrees, required parameter.
     params = copy.deepcopy(basic_parameters)
     del params["sourcedistanceindegrees"]
-    request = client.fetch(_assemble_url('greens', **params))
+    request = client.fetch(_assemble_url('greens_function', **params))
     assert request.code == 400
     assert request.reason == \
         "Required parameter 'sourcedistanceindegrees' not given."
@@ -123,13 +123,13 @@ def test_greens_error_handling(all_clients):
     # Remove the sourcedepthinmeters, required parameter.
     params = copy.deepcopy(basic_parameters)
     del params["sourcedepthinmeters"]
-    request = client.fetch(_assemble_url('greens', **params))
+    request = client.fetch(_assemble_url('greens_function', **params))
     assert request.code == 400
     assert request.reason == \
         "Required parameter 'sourcedepthinmeters' not given."
 
 
-def test_greens_retrieval(all_clients):
+def test_greens_function_retrieval(all_clients):
     """
     Tests if the greens functions requested from the server are identical to
     the one requested with the local instaseis client.
@@ -151,7 +151,7 @@ def test_greens_retrieval(all_clients):
 
     # default parameters
     params = copy.deepcopy(basic_parameters)
-    request = client.fetch(_assemble_url('greens', **params))
+    request = client.fetch(_assemble_url('greens_function', **params))
     # ObsPy needs the filename to be able to directly unpack zip files. We
     # don't have a filename here so we unpack manually.
     st_server = obspy.Stream()
@@ -184,7 +184,7 @@ def test_greens_retrieval(all_clients):
     # miniseed
     params = copy.deepcopy(basic_parameters)
     params["format"] = "miniseed"
-    request = client.fetch(_assemble_url('greens', **params))
+    request = client.fetch(_assemble_url('greens_function', **params))
     st_server = obspy.read(request.buffer)
 
     st_db = db.get_greens_function(


### PR DESCRIPTION
This pull requests adds a route to request Greens Functions in the decomposition of Minson & Dreger (2008).

There might be some room to avoid code duplication, but I am unsure how best to do it. Essentially there are a few functions in GreensHandler and SeismogramHandler which are the same or very similar (and some overlap with seismograms_raw as well):
 - parse arguments: checking for duplicates and required arguments as well as default values is the same in the three routes
 - parse_time_settings is the same in /greens and /seismogram
 - set_headers ist the same in /greens and /seismogram, besides the default label
 - get_ttime is the same in /greens and /seismogram
 - validate geometry is the same in /greens and /seismogram, where it could be simplified in /greens, because greens only works with reciprocal DBs. On the other hand, we can use the same function for both without problem.