### PR TITLE
Minor future request: WGS84 to Geocentric conversion

### DIFF
--- a/advanced_server_configuration_example/event_resolver.py
+++ b/advanced_server_configuration_example/event_resolver.py
@@ -28,7 +28,7 @@ import json
 import obspy
 import os
 
-from instaseis.helpers import wgs84_to_geocentric_latitude
+from instaseis.helpers import elliptic_to_geocentric_latitude
 
 
 CACHE = {}
@@ -95,7 +95,7 @@ def get_event_information(event_id, filename):
     event = copy.deepcopy(events[event_id])
     event["origin_time"] = obspy.UTCDateTime(event["origin_time"])
     # Convert latitude to a geocentric latitude.
-    event["latitude"] = wgs84_to_geocentric_latitude(event["latitude"])
+    event["latitude"] = elliptic_to_geocentric_latitude(event["latitude"])
     return event
 
 

--- a/advanced_server_configuration_example/station_resolver.py
+++ b/advanced_server_configuration_example/station_resolver.py
@@ -65,7 +65,7 @@ import csv
 import io
 import sqlite3
 
-from instaseis.helpers import wgs84_to_geocentric_latitude
+from instaseis.helpers import elliptic_to_geocentric_latitude
 
 
 def parse_station_file(filename):
@@ -147,7 +147,7 @@ def get_coordinates(cursor, networks=(), stations=(), debug=False):
 
     # Convert to geocentric coordinates.
     return [{"network": i[0], "station": i[1],
-             "latitude": wgs84_to_geocentric_latitude(i[2]), "longitude": i[3]}
+             "latitude": elliptic_to_geocentric_latitude(i[2]), "longitude": i[3]}
             for i in cursor.execute(query).fetchall()]
 
 

--- a/doc/advanced_server_configuration.rst
+++ b/doc/advanced_server_configuration.rst
@@ -38,7 +38,7 @@ This callback function is used for the ``/coordinates`` route, as well as
 resolves network and station code searches to actual coordinates. How the
 coordinates are resolved is up to the users but make sure it is fast. Also make
 sure the coordinates are geocentric. Instaseis has a helper function to aid
-with that: :func:`instaseis.helpers.wgs84_to_geocentric_latitude`
+with that: :func:`instaseis.helpers.elliptic_to_geocentric_latitude`
 
 **Affected routes:**
 
@@ -101,7 +101,7 @@ event parameters. Users could choose to call an external web service within
 that function or query a local database. It is used for the ``/event`` route as
 well as event identifier based queries in the ``/seismograms`` route. Make sure
 the coordinates are geocentric. Instaseis has a helper function to aid with
-that: :func:`instaseis.helpers.wgs84_to_geocentric_latitude`
+that: :func:`instaseis.helpers.elliptic_to_geocentric_latitude`
 
 **Affected routes:**
 

--- a/doc/helpers.rst
+++ b/doc/helpers.rst
@@ -1,6 +1,6 @@
 Utility Functions
 =================
 
-.. autofunction:: instaseis.helpers.wgs84_to_geocentric_latitude
+.. autofunction:: instaseis.helpers.elliptic_to_geocentric_latitude
 
-.. autofunction:: instaseis.helpers.geocentric_to_wgs84_latitude
+.. autofunction:: instaseis.helpers.geocentric_to_elliptic_latitude

--- a/instaseis/helpers.py
+++ b/instaseis/helpers.py
@@ -24,13 +24,6 @@ LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(
 
 cache = []
 
-WGS_A = 6378137.0
-WGS_B = 6356752.314245
-
-
-_f = (WGS_A - WGS_B) / WGS_A
-E_2 = 2 * _f - _f ** 2
-
 
 def load_lib():
     if cache:
@@ -66,21 +59,31 @@ def get_band_code(dt):
     return band_code
 
 
-def wgs84_to_geocentric_latitude(lat):
+def elliptic_to_geocentric_latitude(lat, axis_a=6378137.0,
+                                    axis_b=6356752.314245):
     """
-    Convert a latitude defined on the WGS84 ellipsoid to a geocentric one.
+    Convert a latitude defined on an ellipsoid to a geocentric one.
 
-    >>> wgs84_to_geocentric_latitude(0.0)
+    :param lat: The latitude to convert.
+    :param axis_a: The length of the major axis of the planet. Defaults to
+        the value of the WGS84 ellipsoid.
+    :param axis_b: The length of the minor axis of the planet. Defaults to
+        the value of the WGS84 ellipsoid.
+
+    >>> elliptic_to_geocentric_latitude(0.0)
     0.0
-    >>> wgs84_to_geocentric_latitude(90.0)
+    >>> elliptic_to_geocentric_latitude(90.0)
     90.0
-    >>> wgs84_to_geocentric_latitude(-90.0)
+    >>> elliptic_to_geocentric_latitude(-90.0)
     -90.0
-    >>> wgs84_to_geocentric_latitude(45.0)
+    >>> elliptic_to_geocentric_latitude(45.0)
     44.80757678401642
-    >>> wgs84_to_geocentric_latitude(-45.0)
+    >>> elliptic_to_geocentric_latitude(-45.0)
     -44.80757678401642
     """
+    _f = (axis_a - axis_b) / axis_a
+    E_2 = 2 * _f - _f ** 2
+
     # Singularities close to the pole and the equator. Just return the value
     # in that case.
     if abs(lat) < 1E-6 or abs(lat - 90) < 1E-6 or \
@@ -90,21 +93,31 @@ def wgs84_to_geocentric_latitude(lat):
     return math.degrees(math.atan((1 - E_2) * math.tan(math.radians(lat))))
 
 
-def geocentric_to_wgs84_latitude(lat):
+def geocentric_to_elliptic_latitude(lat, axis_a=6378137.0,
+                                    axis_b=6356752.314245):
     """
-    Convert a geocentric latitude to one defined on the WGS84 ellipsoid.
+    Convert a geocentric latitude to one defined on an ellipsoid.
 
-    >>> geocentric_to_wgs84_latitude(0.0)
+    :param lat: The latitude to convert.
+    :param axis_a: The length of the major axis of the planet. Defaults to
+        the value of the WGS84 ellipsoid.
+    :param axis_b: The length of the minor axis of the planet. Defaults to
+        the value of the WGS84 ellipsoid.
+
+    >>> geocentric_to_elliptic_latitude(0.0)
     0.0
-    >>> geocentric_to_wgs84_latitude(90.0)
+    >>> geocentric_to_elliptic_latitude(90.0)
     90.0
-    >>> geocentric_to_wgs84_latitude(-90.0)
+    >>> geocentric_to_elliptic_latitude(-90.0)
     -90.0
-    >>> geocentric_to_wgs84_latitude(45.0)
+    >>> geocentric_to_elliptic_latitude(45.0)
     45.19242321598358
-    >>> geocentric_to_wgs84_latitude(-45.0)
+    >>> geocentric_to_elliptic_latitude(-45.0)
     -45.19242321598358
     """
+    _f = (axis_a - axis_b) / axis_a
+    E_2 = 2 * _f - _f ** 2
+
     # Singularities close to the pole and the equator. Just return the value
     # in that case.
     if abs(lat) < 1E-6 or abs(lat - 90) < 1E-6 or \

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -19,7 +19,7 @@ import tornado.web
 from ... import Source, Receiver
 from ..util import run_async, _validtimesetting
 from ..instaseis_request import InstaseisTimeSeriesHandler
-from ...helpers import geocentric_to_wgs84_latitude
+from ...helpers import geocentric_to_elliptic_latitude
 
 
 @run_async
@@ -96,7 +96,7 @@ def _get_greens(db, epicentral_distance_degree, source_depth_in_m, units, dt,
             # Write SAC headers.
             tr.stats.sac = obspy.core.AttribDict()
             # Write WGS84 coordinates to the SAC files.
-            tr.stats.sac.stla = geocentric_to_wgs84_latitude(
+            tr.stats.sac.stla = geocentric_to_elliptic_latitude(
                 90.0 - epicentral_distance_degree)
             tr.stats.sac.stlo = 0.0
             tr.stats.sac.stdp = 0.0

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -18,7 +18,7 @@ import tornado.web
 from ... import Source, ForceSource, Receiver
 from ..util import run_async, IOQueue, _validtimesetting
 from ..instaseis_request import InstaseisTimeSeriesHandler
-from ...helpers import geocentric_to_wgs84_latitude
+from ...helpers import geocentric_to_elliptic_latitude
 
 
 @run_async
@@ -95,11 +95,13 @@ def _get_seismogram(db, source, receiver, components, units, dt, kernelwidth,
             # Write SAC headers.
             tr.stats.sac = obspy.core.AttribDict()
             # Write WGS84 coordinates to the SAC files.
-            tr.stats.sac.stla = geocentric_to_wgs84_latitude(receiver.latitude)
+            tr.stats.sac.stla = geocentric_to_elliptic_latitude(
+                receiver.latitude)
             tr.stats.sac.stlo = receiver.longitude
             tr.stats.sac.stdp = receiver.depth_in_m
             tr.stats.sac.stel = 0.0
-            tr.stats.sac.evla = geocentric_to_wgs84_latitude(source.latitude)
+            tr.stats.sac.evla = geocentric_to_elliptic_latitude(
+                source.latitude)
             tr.stats.sac.evlo = source.longitude
             tr.stats.sac.evdp = source.depth_in_m
             # Force source has no magnitude.

--- a/instaseis/tests/test_instaseis.py
+++ b/instaseis/tests/test_instaseis.py
@@ -23,8 +23,8 @@ import shutil
 from instaseis.instaseis_db import InstaseisDB
 from instaseis.base_instaseis_db import _get_seismogram_times
 from instaseis import Source, Receiver, ForceSource
-from instaseis.helpers import (get_band_code, wgs84_to_geocentric_latitude,
-                               geocentric_to_wgs84_latitude)
+from instaseis.helpers import (get_band_code, elliptic_to_geocentric_latitude,
+                               geocentric_to_elliptic_latitude)
 
 from .testdata import BWD_TEST_DATA, FWD_TEST_DATA
 from .testdata import BWD_STRAIN_ONLY_TEST_DATA, BWD_FORCE_TEST_DATA
@@ -675,7 +675,7 @@ def test_higher_level_event_and_receiver_parsing():
     # Convert everything to WGS84 values. Instaseis will assume them to be
     # wgs84 and convert it to geocentric.
 
-    org.latitude = geocentric_to_wgs84_latitude(89.91)
+    org.latitude = geocentric_to_elliptic_latitude(89.91)
     org.longitude = 0.0
     org.depth = 12000
     org.time = obspy.UTCDateTime(2014, 1, 5)
@@ -688,7 +688,7 @@ def test_higher_level_event_and_receiver_parsing():
 
     # Same with the receiver objects.
     inv = obspy.read_inventory(os.path.join(DATA, "TA.Q56A..BH.xml"))
-    inv[0][0].latitude = geocentric_to_wgs84_latitude(42.6390)
+    inv[0][0].latitude = geocentric_to_elliptic_latitude(42.6390)
     inv[0][0].longitude = 74.4940
     inv[0][0].elevation = 0.0
     inv[0][0].channels = []
@@ -1240,56 +1240,56 @@ def test_wgs84_to_geocentric():
     """
     Tests the utility function.
     """
-    assert wgs84_to_geocentric_latitude(0.0) == 0.0
-    assert wgs84_to_geocentric_latitude(90.0) == 90.0
-    assert wgs84_to_geocentric_latitude(-90.0) == -90.0
+    assert elliptic_to_geocentric_latitude(0.0) == 0.0
+    assert elliptic_to_geocentric_latitude(90.0) == 90.0
+    assert elliptic_to_geocentric_latitude(-90.0) == -90.0
 
     # Difference minimal close to the poles and the equator.
-    assert abs(wgs84_to_geocentric_latitude(0.1) - 0.1) < 1E-3
-    assert abs(wgs84_to_geocentric_latitude(-0.1) + 0.1) < 1E-3
-    assert abs(wgs84_to_geocentric_latitude(89.9) - 89.9) < 1E-3
-    assert abs(wgs84_to_geocentric_latitude(-89.9) + 89.9) < 1E-3
+    assert abs(elliptic_to_geocentric_latitude(0.1) - 0.1) < 1E-3
+    assert abs(elliptic_to_geocentric_latitude(-0.1) + 0.1) < 1E-3
+    assert abs(elliptic_to_geocentric_latitude(89.9) - 89.9) < 1E-3
+    assert abs(elliptic_to_geocentric_latitude(-89.9) + 89.9) < 1E-3
 
     # The geographic latitude is larger then the geocentric on the northern
     # hemisphere.
     for _i in range(1, 90):
-        assert _i > wgs84_to_geocentric_latitude(_i)
+        assert _i > elliptic_to_geocentric_latitude(_i)
 
     # The opposite is true on the southern hemisphere.
     for _i in range(-1, -90, -1):
-        assert _i < wgs84_to_geocentric_latitude(_i)
+        assert _i < elliptic_to_geocentric_latitude(_i)
 
     # Small check to test the approximate ranges.
-    assert 0.19 < 45.0 - wgs84_to_geocentric_latitude(45.0) < 0.2
-    assert -0.19 > -45 - wgs84_to_geocentric_latitude(-45.0) > -0.2
+    assert 0.19 < 45.0 - elliptic_to_geocentric_latitude(45.0) < 0.2
+    assert -0.19 > -45 - elliptic_to_geocentric_latitude(-45.0) > -0.2
 
 
 def test_geocentric_to_wgs84():
     """
     Tests the utility function.
     """
-    assert geocentric_to_wgs84_latitude(0.0) == 0.0
-    assert geocentric_to_wgs84_latitude(90.0) == 90.0
-    assert geocentric_to_wgs84_latitude(-90.0) == -90.0
+    assert geocentric_to_elliptic_latitude(0.0) == 0.0
+    assert geocentric_to_elliptic_latitude(90.0) == 90.0
+    assert geocentric_to_elliptic_latitude(-90.0) == -90.0
 
     # Difference minimal close to the poles and the equator.
-    assert abs(geocentric_to_wgs84_latitude(0.1) - 0.1) < 1E-3
-    assert abs(geocentric_to_wgs84_latitude(-0.1) + 0.1) < 1E-3
-    assert abs(geocentric_to_wgs84_latitude(89.9) - 89.9) < 1E-3
-    assert abs(geocentric_to_wgs84_latitude(-89.9) + 89.9) < 1E-3
+    assert abs(geocentric_to_elliptic_latitude(0.1) - 0.1) < 1E-3
+    assert abs(geocentric_to_elliptic_latitude(-0.1) + 0.1) < 1E-3
+    assert abs(geocentric_to_elliptic_latitude(89.9) - 89.9) < 1E-3
+    assert abs(geocentric_to_elliptic_latitude(-89.9) + 89.9) < 1E-3
 
     # The geographic latitude is larger then the geocentric on the northern
     # hemisphere.
     for _i in range(1, 90):
-        assert _i < geocentric_to_wgs84_latitude(_i)
+        assert _i < geocentric_to_elliptic_latitude(_i)
 
     # The opposite is true on the southern hemisphere.
     for _i in range(-1, -90, -1):
-        assert _i > geocentric_to_wgs84_latitude(_i)
+        assert _i > geocentric_to_elliptic_latitude(_i)
 
     # Small check to test the approximate ranges.
-    assert -0.19 > 45.0 - geocentric_to_wgs84_latitude(45.0) > -0.2
-    assert 0.19 < -45 - geocentric_to_wgs84_latitude(-45.0) < 0.2
+    assert -0.19 > 45.0 - geocentric_to_elliptic_latitude(45.0) > -0.2
+    assert 0.19 < -45 - geocentric_to_elliptic_latitude(-45.0) < 0.2
 
 
 def test_coordinate_conversions_round_trips():
@@ -1299,10 +1299,10 @@ def test_coordinate_conversions_round_trips():
     values = np.linspace(-90, 90, 100)
     for value in values:
         value = float(value)
-        there = wgs84_to_geocentric_latitude(value)
-        back = geocentric_to_wgs84_latitude(there)
+        there = elliptic_to_geocentric_latitude(value)
+        back = geocentric_to_elliptic_latitude(there)
         assert abs(back - value) < 1E-12
 
-        there = geocentric_to_wgs84_latitude(value)
-        back = wgs84_to_geocentric_latitude(there)
+        there = geocentric_to_elliptic_latitude(value)
+        back = elliptic_to_geocentric_latitude(there)
         assert abs(back - value) < 1E-12

--- a/instaseis/tests/test_receiver.py
+++ b/instaseis/tests/test_receiver.py
@@ -16,7 +16,7 @@ import os
 import pytest
 
 from instaseis import Receiver, ReceiverParseError
-from instaseis.helpers import wgs84_to_geocentric_latitude
+from instaseis.helpers import elliptic_to_geocentric_latitude
 
 DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
@@ -39,11 +39,11 @@ def test_parse_STATIONS_file(tmpdir):
 
     rec = receivers[0]
     assert (rec.latitude, rec.longitude, rec.network, rec.station) == \
-           (wgs84_to_geocentric_latitude(10.0), 20.0, "II", "AAK")
+           (elliptic_to_geocentric_latitude(10.0), 20.0, "II", "AAK")
 
     rec = receivers[1]
     assert (rec.latitude, rec.longitude, rec.network, rec.station) == \
-           (wgs84_to_geocentric_latitude(20.0), 30.0, "AA", "BBK")
+           (elliptic_to_geocentric_latitude(20.0), 30.0, "AA", "BBK")
 
 
 def test_parse_StationXML():
@@ -54,7 +54,7 @@ def test_parse_StationXML():
     rec = receivers[0]
 
     assert (rec.latitude, rec.longitude, rec.network, rec.station) == \
-        (wgs84_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
+        (elliptic_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
 
 
 def test_parse_obspy_objects():
@@ -65,19 +65,19 @@ def test_parse_obspy_objects():
     assert len(receivers) == 1
     rec = receivers[0]
     assert (rec.latitude, rec.longitude, rec.network, rec.station) == \
-           (wgs84_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
+           (elliptic_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
 
     receivers = Receiver.parse(inv[0])
     assert len(receivers) == 1
     rec = receivers[0]
     assert (rec.latitude, rec.longitude, rec.network, rec.station) == \
-           (wgs84_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
+           (elliptic_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
 
     receivers = Receiver.parse(inv[0][0], network_code="TA")
     assert len(receivers) == 1
     rec = receivers[0]
     assert (rec.latitude, rec.longitude, rec.network, rec.station) == \
-           (wgs84_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
+           (elliptic_to_geocentric_latitude(39.041), -79.1871, "TA", "Q56A")
 
 
 def test_parse_sac_files():
@@ -88,7 +88,7 @@ def test_parse_sac_files():
     rec = receivers[0]
     assert (round(rec.latitude, 3), round(rec.longitude, 3),
             rec.network, rec.station) == \
-        (round(wgs84_to_geocentric_latitude(34.94598), 3),
+        (round(elliptic_to_geocentric_latitude(34.94598), 3),
          round(-106.45713, 3), 'IU', 'ANMO')
 
 
@@ -112,7 +112,7 @@ def test_parse_obspy_waveform_objects():
     # Coordinates are assumed to be WGS84 and will be converted to geocentric.
     assert (round(rec.latitude, 3), round(rec.longitude, 3),
             rec.network, rec.station) == \
-           (round(wgs84_to_geocentric_latitude(34.94598), 3),
+           (round(elliptic_to_geocentric_latitude(34.94598), 3),
             round(-106.45713, 3), 'IU', 'ANMO')
 
     # From trace.
@@ -121,7 +121,7 @@ def test_parse_obspy_waveform_objects():
     rec = receivers[0]
     assert (round(rec.latitude, 3), round(rec.longitude, 3),
             rec.network, rec.station) == \
-           (round(wgs84_to_geocentric_latitude(34.94598), 3),
+           (round(elliptic_to_geocentric_latitude(34.94598), 3),
             round(-106.45713, 3), 'IU', 'ANMO')
 
 
@@ -141,7 +141,7 @@ def test_duplicate_receivers():
     # Coordinates are assumed to be WGS84 and will be converted to geocentric.
     assert (round(rec.latitude, 3), round(rec.longitude, 3),
             rec.network, rec.station) == \
-           (round(wgs84_to_geocentric_latitude(34.94598), 3),
+           (round(elliptic_to_geocentric_latitude(34.94598), 3),
             round(-106.45713, 3), 'IU', 'ANMO')
 
 
@@ -153,7 +153,7 @@ def test_dataless_seed_files():
     # Coordinates are assumed to be WGS84 and will be converted to geocentric.
     assert (round(rec.latitude, 3), round(rec.longitude, 3),
             rec.network, rec.station) == \
-           (round(wgs84_to_geocentric_latitude(48.162899), 3),
+           (round(elliptic_to_geocentric_latitude(48.162899), 3),
             round(11.2752, 3), 'BW', 'FURT')
 
 

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -20,7 +20,7 @@ import obspy
 import numpy as np
 from .tornado_testing_fixtures import *  # NOQA
 
-from instaseis.helpers import geocentric_to_wgs84_latitude
+from instaseis.helpers import geocentric_to_elliptic_latitude
 
 # Conditionally import mock either from the stdlib or as a separate library.
 import sys
@@ -4299,12 +4299,14 @@ def test_sac_headers(all_clients):
         assert tr.stats._format == "SAC"
         # Instaseis will write SAC coordinates in WGS84!
         # Assert the station headers.
-        assert abs(tr.stats.sac.stla - geocentric_to_wgs84_latitude(22)) < 1E-6
+        assert abs(tr.stats.sac.stla -
+                   geocentric_to_elliptic_latitude(22)) < 1E-6
         assert abs(tr.stats.sac.stlo - 44) < 1E-6
         assert abs(tr.stats.sac.stdp - 0.0) < 1E-6
         assert abs(tr.stats.sac.stel - 0.0) < 1E-6
         # Assert the event parameters.
-        assert abs(tr.stats.sac.evla - geocentric_to_wgs84_latitude(1)) < 1E-6
+        assert abs(tr.stats.sac.evla -
+                   geocentric_to_elliptic_latitude(1)) < 1E-6
         assert abs(tr.stats.sac.evlo - 12) < 1E-6
         assert abs(tr.stats.sac.evdp - client.source_depth) < 1E-6
         assert abs(tr.stats.sac.mag - 4.22) < 1E-2

--- a/instaseis/tests/test_source.py
+++ b/instaseis/tests/test_source.py
@@ -16,7 +16,7 @@ import os
 import numpy as np
 
 from instaseis import Source, FiniteSource
-from instaseis.helpers import wgs84_to_geocentric_latitude
+from instaseis.helpers import elliptic_to_geocentric_latitude
 from instaseis.source import moment2magnitude, magnitude2moment
 from instaseis.source import fault_vectors_lmn, strike_dip_rake_from_ln
 
@@ -58,7 +58,7 @@ def test_parse_CMTSOLUTIONS_file(tmpdir):
     # Latitude will have assumed to be WGS84 and converted to geocentric
     # latitude.
     np.testing.assert_allclose(src_params, np.array(
-        (wgs84_to_geocentric_latitude(37.91), -77.93, 12000, 4.71E17,
+        (elliptic_to_geocentric_latitude(37.91), -77.93, 12000, 4.71E17,
          3.81E15, -4.74E17, 3.99E16, -8.05E16,
          -1.23E17), dtype="float64"))
     assert src.origin_time == origin_time
@@ -87,7 +87,7 @@ def _assert_src(src):
     # Latitude will have been assumed to be WGS84 and converted to geocentric!
     assert (src.latitude, src.longitude, src.depth_in_m, src.m_rr, src.m_tt,
             src.m_pp, src.m_rt, src.m_rp, src.m_tp) == \
-           (wgs84_to_geocentric_latitude(36.97), -3.54, 609800.0, -2.16E18,
+           (elliptic_to_geocentric_latitude(36.97), -3.54, 609800.0, -2.16E18,
             5.36E17, 1.62E18, 1.3E16, 3.23E18, 1.75E18)
 
     # Also check the time!


### PR DESCRIPTION
The wgs84-geocentric conversion only uses the min/max radius of the Earth. Can you make it a parameter to be used for other planets as well?