### PR TITLE
Syngine client

### DIFF
--- a/doc/instaseis.rst
+++ b/doc/instaseis.rst
@@ -37,3 +37,11 @@ RemoteInstaseisDB
 
 .. autoclass:: instaseis.remote_instaseis_db.RemoteInstaseisDB
     :members:
+
+....
+
+SyngineInstaseisDB
+------------------
+
+.. autoclass:: instaseis.syngine_instaseis_db.SyngineInstaseisDB
+:members:

--- a/instaseis/__init__.py
+++ b/instaseis/__init__.py
@@ -64,7 +64,7 @@ def open_db(path, *args, **kwargs):
     The special syntax ``syngine://MODEL_NAME`` will connect to the IRIS
     syngine web service for the specified model.
 
-    >>> db = instaseis.open_db("syngine://prem")
+    >>> db = instaseis.open_db("syngine://ak135f")
     >>> print(db)
     SyngineInstaseisDB reciprocal Green's function Database (v7) ...
     Syngine model name:      'ak135f'

--- a/instaseis/__init__.py
+++ b/instaseis/__init__.py
@@ -61,6 +61,17 @@ def open_db(path, *args, **kwargs):
         components           : vertical and horizontal
         velocity model       : ak135f
 
+    The special syntax ``syngine://MODEL_NAME`` will connect to the IRIS
+    syngine web service for the specified model.
+
+    >>> db = instaseis.open_db("syngine://prem")
+    >>> print(db)
+    SyngineInstaseisDB reciprocal Green's function Database (v7) ...
+    Syngine model name:      'ak135f'
+    Syngine service version:  0.0.2
+        components           : vertical and horizontal
+        velocity model       : ak135f
+
     .. note::
 
         If opening a local database and the ``ordered_output.nc4`` files are
@@ -69,7 +80,12 @@ def open_db(path, *args, **kwargs):
         :func:`~instaseis.open_db` function. Instaseis will recursively
         search the child directories for the  necessary files and open them.
     """
-    if "://" in path:
+    if path.startswith("syngine://"):
+        model = path.lstrip("syngine://")
+        from . import syngine_instaseis_db
+        return syngine_instaseis_db.SyngineInstaseisDB(model=model, *args,
+                                                       **kwargs)
+    elif "://" in path:
         from . import remote_instaseis_db
         return remote_instaseis_db.RemoteInstaseisDB(path, *args, **kwargs)
     else:

--- a/instaseis/base_instaseis_db.py
+++ b/instaseis/base_instaseis_db.py
@@ -594,6 +594,9 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
         self.__cached_info = AttribDict(self._get_info())
         return self.__cached_info
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def __str__(self):
         info = self.info
 

--- a/instaseis/remote_instaseis_db.py
+++ b/instaseis/remote_instaseis_db.py
@@ -110,7 +110,7 @@ class RemoteInstaseisDB(BaseInstaseisDB):
         r = requests.get(url)
         if "Instaseis-Mu" not in r.headers:
             warnings.warn("Mu is not passed via the HTTP headers. Maybe some "
-                          "proxy removed it? Mu is now always the default me.",
+                          "proxy removed it? Mu is now always the default mu.",
                           InstaseisWarning)
             mu = DEFAULT_MU
         else:

--- a/instaseis/syngine_instaseis_db.py
+++ b/instaseis/syngine_instaseis_db.py
@@ -15,10 +15,12 @@ from __future__ import (absolute_import, division, print_function,
 import io
 import numpy as np
 import obspy
+import platform
 import requests
 import warnings
 
-from . import InstaseisError, InstaseisWarning, Source, ForceSource
+from . import (InstaseisError, InstaseisWarning, Source, ForceSource,
+               __version__)
 from .base_instaseis_db import BaseInstaseisDB, DEFAULT_MU
 
 from .helpers import geocentric_to_elliptic_latitude
@@ -26,6 +28,12 @@ from .helpers import geocentric_to_elliptic_latitude
 from future import standard_library
 with standard_library.hooks():
     from urllib.parse import urlencode
+
+
+USER_AGENT = "Instaseis %s (%s, Python %s)" % (__version__,
+                                               platform.platform(),
+                                               platform.python_version())
+HEADERS = {"User-Agent": USER_AGENT}
 
 
 class SyngineInstaseisDB(BaseInstaseisDB):
@@ -114,7 +122,7 @@ class SyngineInstaseisDB(BaseInstaseisDB):
         if self.debug:
             print("Downloading '%s' ..." % url)
 
-        r = requests.get(url)
+        r = requests.get(url, headers=HEADERS)
 
         if self.debug:
             print("Downloaded '%s' with status code %i." % (url,
@@ -166,7 +174,7 @@ class SyngineInstaseisDB(BaseInstaseisDB):
         """
         if self.debug:
             print("Downloading '%s' ..." % url)
-        r = requests.get(url)
+        r = requests.get(url, headers=HEADERS)
         if self.debug:
             print("Downloaded '%s' with status code %i." % (url,
                                                             r.status_code))

--- a/instaseis/syngine_instaseis_db.py
+++ b/instaseis/syngine_instaseis_db.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Instaseis database class for remote access over HTTP.
+Instaseis database class for remote access using the syngine service of IRIS.
 
 :copyright:
-    Lion Krischer (krischer@geophysik.uni-muenchen.de), 2014
+    Lion Krischer (krischer@geophysik.uni-muenchen.de), 2015
 :license:
     GNU Lesser General Public License, Version 3 [non-commercial/academic use]
     (http://www.gnu.org/copyleft/lgpl.html)

--- a/instaseis/syngine_instaseis_db.py
+++ b/instaseis/syngine_instaseis_db.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Instaseis database class for remote access over HTTP.
+
+:copyright:
+    Lion Krischer (krischer@geophysik.uni-muenchen.de), 2014
+:license:
+    GNU Lesser General Public License, Version 3 [non-commercial/academic use]
+    (http://www.gnu.org/copyleft/lgpl.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import io
+import numpy as np
+import obspy
+import requests
+import warnings
+
+from . import InstaseisError, InstaseisWarning, Source, ForceSource, \
+    __version__
+from .base_instaseis_db import BaseInstaseisDB, DEFAULT_MU
+
+from .helpers import geocentric_to_elliptic_latitude
+
+from future import standard_library
+with standard_library.hooks():
+    from urllib.parse import urlencode, urlparse
+
+
+class SyngineInstaseisDB(BaseInstaseisDB):
+    """
+    Remote Instaseis interface connecting with IRIS' syngine service.
+    """
+    def __init__(self, model,
+                 base_url="http://service.iris.edu/irisws/syngine/1",
+                 debug=False, *args, **kwargs):
+        """
+        :param model: The model to use.
+        :type model: str
+        :param base_url: URL to the root of the syngine service.
+        :type base_url: str
+        :param debug: Debug messages on/off.
+        :type debug: bool
+        """
+        self.model = model
+        self.debug = debug
+        self.base_url = base_url.rstrip("/")
+
+        # Download once to make sure it works and the model exists.
+        self.info
+
+        # Get the version of the service.
+        self.syngine_service_version = self._download_url(self._get_url(
+            path="version"))
+
+    def _get_seismograms(self, source, receiver, components=("Z", "N", "E")):
+        """
+        Extract seismograms.
+
+        :param source: instaseis.Source or instaseis.ForceSource object
+        :type source: :class:`instaseis.source.Source` or
+            :class:`instaseis.source.ForceSource`
+        :param receiver: instaseis.Receiver object
+        :type receiver: :class:`instaseis.source.Receiver`
+        :param components: a tuple containing any combination of the
+            strings ``"Z"``, ``"N"``, ``"E"``, ``"R"``, and ``"T"``
+        """
+        # Collect parameters.
+        params = {"components": "".join(components).upper()}
+
+        params["model"] = self.model
+        params["format"] = "miniseed"
+
+        params["units"] = "velocity"
+        # No resampling!
+        params["dt"] = self.info.dt
+
+        # Carefully set the starttime to get everything. This is a bit
+        # awkward and we essentially have to undo what the /seismograms
+        # route is doing...
+        params["origintime"] = str(obspy.UTCDateTime(0))
+        params["starttime"] = str(obspy.UTCDateTime(-(self.info.src_shift)))
+
+        # Start with the receiver.
+        # syngine uses WGS84 coordinates - we assume geocentric ones. Thus
+        # we have to convert.
+        params["receiverlatitude"] = geocentric_to_elliptic_latitude(
+            receiver.latitude)
+        params["receiverlongitude"] = receiver.longitude
+        if receiver.depth_in_m:
+            warnings.warn("The syngine service only services reciprocal "
+                          "databases thus the receiver depth cannot be "
+                          "changed.", UserWarning)
+
+        # Do the source.
+        params["sourcelatitude"] = geocentric_to_elliptic_latitude(
+            source.latitude)
+        params["sourcelongitude"] = source.longitude
+        if source.depth_in_m is not None:
+            params["sourcedepthinmeters"] = source.depth_in_m
+        if isinstance(source, ForceSource):
+            params["sourceforce"] = ",".join([params["fr"], params["ft"],
+                                              params["fp"]])
+        elif isinstance(source, Source):
+            params["sourcemomenttensor"] = ",".join(map(str, [
+                source.m_rr, source.m_tt, source.m_pp, source.m_rt,
+                source.m_rp, source.m_tp]))
+        else:
+            raise NotImplementedError
+
+        url = self._get_url(path="query", **params)
+
+        if self.debug:
+            print("Downloading '%s' ..." % url)
+
+        r = requests.get(url)
+
+        if self.debug:
+            print("Downloaded '%s' with status code %i." % (url,
+                                                            r.status_code))
+
+        if r.status_code != 200:
+            # Right now one has to parse the body of the response to get the
+            # message.
+            reason = r.content.decode().strip().split("\n")[0]
+            raise InstaseisError(
+                "Status code %i when downloading '%s'. Reason: '%s'" % (
+                r.status_code, url, reason))
+
+        if "Instaseis-Mu" not in r.headers:
+            warnings.warn("Mu is not passed via the HTTP headers. Maybe some "
+                          "proxy removed it? Mu is now always the default mu.",
+                          InstaseisWarning)
+            mu = DEFAULT_MU
+        else:
+            mu = float(r.headers["Instaseis-Mu"])
+
+        with io.BytesIO(r.content) as fh:
+            fh.seek(0, 0)
+            st = obspy.read(fh)
+
+        # Convert back to dictionary of numpy arrays...this is a bit
+        # redundant but plays nice with the rest of Instaseis and still
+        # enables a REST API that serves MiniSEED files.
+        data = {
+            "mu": mu
+        }
+
+        for tr in st:
+            data[tr.stats.channel[-1].upper()] = tr.data
+
+        return data
+
+    def _get_url(self, path, **kwargs):
+        path = path.strip("/")
+        url = "%s/%s" % (self.base_url, path)
+
+        if kwargs:
+            url += "?%s" % urlencode(kwargs)
+        return url
+
+    def _download_url(self, url, unpack_json=False):
+        """
+        Helper function downloading data from a URL.
+        """
+        if self.debug:
+            print("Downloading '%s' ..." % url)
+        r = requests.get(url)
+        if self.debug:
+            print("Downloaded '%s' with status code %i." % (url,
+                                                            r.status_code))
+        if r.status_code == 400:
+            raise InstaseisError("Model '%s' not available on the syngine "
+                                 "service?" % self.model)
+        elif r.status_code != 200:
+            raise InstaseisError("Status code %i when downloading '%s'" % (
+                r.status_code, url))
+        if unpack_json is True:
+            return r.json()
+        else:
+            return r.text
+
+    def _get_info(self):
+        """
+        Returns a dictionary with information about the currently loaded
+        database.
+        """
+        info = self._download_url(self._get_url(path="info",
+                                                model=self.model),
+                                  unpack_json=True)
+        info["directory"] = self.base_url
+        # Convert types lost in the translation to JSON.
+        info["datetime"] = obspy.UTCDateTime(info["datetime"])
+        info["slip"] = np.array(info["slip"], dtype=np.float64)
+        info["sliprate"] = np.array(info["sliprate"], dtype=np.float64)
+
+        return info
+
+    def __str__(self):
+        base = BaseInstaseisDB.__str__(self).splitlines()
+        base.insert(1, "Syngine model name:      '%s'" % self.model)
+        base.insert(2, "Syngine service version:  %s" %
+                    self.syngine_service_version)
+        return "\n".join(base)
+

--- a/instaseis/syngine_instaseis_db.py
+++ b/instaseis/syngine_instaseis_db.py
@@ -18,15 +18,14 @@ import obspy
 import requests
 import warnings
 
-from . import InstaseisError, InstaseisWarning, Source, ForceSource, \
-    __version__
+from . import InstaseisError, InstaseisWarning, Source, ForceSource
 from .base_instaseis_db import BaseInstaseisDB, DEFAULT_MU
 
 from .helpers import geocentric_to_elliptic_latitude
 
 from future import standard_library
 with standard_library.hooks():
-    from urllib.parse import urlencode, urlparse
+    from urllib.parse import urlencode
 
 
 class SyngineInstaseisDB(BaseInstaseisDB):
@@ -127,7 +126,7 @@ class SyngineInstaseisDB(BaseInstaseisDB):
             reason = r.content.decode().strip().split("\n")[0]
             raise InstaseisError(
                 "Status code %i when downloading '%s'. Reason: '%s'" % (
-                r.status_code, url, reason))
+                    r.status_code, url, reason))
 
         if "Instaseis-Mu" not in r.headers:
             warnings.warn("Mu is not passed via the HTTP headers. Maybe some "
@@ -210,4 +209,3 @@ class SyngineInstaseisDB(BaseInstaseisDB):
         base.insert(2, "Syngine service version:  %s" %
                     self.syngine_service_version)
         return "\n".join(base)
-

--- a/instaseis/syngine_instaseis_db.py
+++ b/instaseis/syngine_instaseis_db.py
@@ -196,6 +196,12 @@ class SyngineInstaseisDB(BaseInstaseisDB):
         info["slip"] = np.array(info["slip"], dtype=np.float64)
         info["sliprate"] = np.array(info["sliprate"], dtype=np.float64)
 
+        # Syngine currently appears to use an outdated instaseis version or
+        # they cached their /info routes.
+        if info["max_radius"] > 10000:
+            info["max_radius"] /= 1E3
+            info["min_radius"] /= 1E3
+
         return info
 
     def __str__(self):

--- a/instaseis/tests/test_syngine_instaseis_client.py
+++ b/instaseis/tests/test_syngine_instaseis_client.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Tests for the syngine client. These tests might have to be adapted if the
+service changes.
+
+:copyright:
+    Lion Krischer (krischer@geophysik.uni-muenchen.de), 2014
+:license:
+    GNU Lesser General Public License, Version 3 [non-commercial/academic use]
+    (http://www.gnu.org/copyleft/lgpl.html)
+"""
+from __future__ import absolute_import
+
+import copy
+import numpy as np
+import pytest
+
+import instaseis
+from .tornado_testing_fixtures import DBS
+
+db_path = DBS["db_bwd_displ_only"]
+
+
+@pytest.fixture(scope="module")
+def syngine_client():
+    return instaseis.open_db("syngine://test", debug=True)
+
+
+def test_info(syngine_client):
+    """
+    Make sure the /info route is similar enough.
+    """
+    # Syngine and local database.
+    s_db = syngine_client
+    l_db = instaseis.open_db(db_path)
+
+    s_info = copy.deepcopy(s_db.info)
+    l_info = copy.deepcopy(l_db.info)
+
+    np.testing.assert_allclose(s_info.slip, l_info.slip)
+    np.testing.assert_allclose(s_info.sliprate, l_info.sliprate)
+
+    for key in ["directory", "slip", "sliprate"]:
+        del s_info[key]
+        del l_info[key]
+
+    assert s_info.__dict__ == l_info.__dict__
+
+
+def _compare_streams(s_db, l_db, kwargs):
+    """
+    Helper function comparing streams extracted from syngine and remote
+    instaseis databases.
+    """
+    s_st = s_db.get_seismograms(**kwargs)
+    l_st = l_db.get_seismograms(**kwargs)
+
+    assert len(s_st) == len(l_st)
+
+    for s_tr, l_tr in zip(s_st, l_st):
+        assert s_tr.stats.__dict__ == l_tr.stats.__dict__
+        # Very small values have issues with floating point accuracy. 7
+        # orders of magnitude should be more than accurate enough.
+        np.testing.assert_allclose(s_tr.data, l_tr.data,
+                                   atol=1E-6 * s_tr.data.ptp())
+
+
+def test_seismogram_extraction(syngine_client):
+    """
+    Test the seismogram extraction from local and syngine databases.
+    """
+    # syngine and local database.
+    s_db = syngine_client
+    l_db = instaseis.open_db(db_path)
+
+    source = instaseis.Source(
+        latitude=4., longitude=3.0, depth_in_m=0, m_rr=4.71e+17, m_tt=3.81e+17,
+        m_pp=-4.74e+17, m_rt=3.99e+17, m_rp=-8.05e+17, m_tp=-1.23e+17)
+
+    receiver = instaseis.Receiver(latitude=10., longitude=20., depth_in_m=None)
+
+    kwargs = {"source": source, "receiver": receiver,
+              "components": ["Z", "N", "E", "R", "T"]}
+    _compare_streams(s_db, l_db, kwargs)
+
+    # Test velocity and acceleration.
+    kwargs = {"source": source, "receiver": receiver,
+              "components": ["Z", "N", "E", "R", "T"], "kind": "velocity"}
+    _compare_streams(s_db, l_db, kwargs)
+    kwargs = {"source": source, "receiver": receiver,
+              "components": ["Z", "N", "E", "R", "T"], "kind": "acceleration"}
+    _compare_streams(s_db, l_db, kwargs)
+
+    # Test remove source shift.
+    kwargs = {"source": source, "receiver": receiver,
+              "components": ["Z", "N", "E", "R", "T"],
+              "remove_source_shift": False}
+    _compare_streams(s_db, l_db, kwargs)
+
+    # Test resampling.
+    kwargs = {"source": source, "receiver": receiver,
+              "components": ["Z", "N", "E", "R", "T"],
+              "dt": 1.0, "kernelwidth": 6}
+    _compare_streams(s_db, l_db, kwargs)
+
+    # Test force source.
+    if "displ_only" in s_db._client.filepath:
+        source = instaseis.ForceSource(
+            latitude=89.91, longitude=0.0, depth_in_m=12000,
+            f_r=1.23E10,
+            f_t=2.55E10,
+            f_p=1.73E10)
+        kwargs = {"source": source, "receiver": receiver}
+        _compare_streams(s_db, l_db, kwargs)

--- a/instaseis/tests/test_syngine_instaseis_client.py
+++ b/instaseis/tests/test_syngine_instaseis_client.py
@@ -24,7 +24,7 @@ db_path = DBS["db_bwd_displ_only"]
 
 @pytest.fixture(scope="module")
 def syngine_client():
-    return instaseis.open_db("syngine://test", debug=True)
+    return instaseis.open_db("syngine://test")
 
 
 def test_info(syngine_client):
@@ -59,9 +59,15 @@ def _compare_streams(s_db, l_db, kwargs):
     assert len(s_st) == len(l_st)
 
     for s_tr, l_tr in zip(s_st, l_st):
+        # XXX: Delete the mu for now. Once implemented on the instaseis
+        # server and forwarded by IRIS we will use it here.
+        del s_tr.stats.instaseis
+        del l_tr.stats.instaseis
+
         assert s_tr.stats.__dict__ == l_tr.stats.__dict__
         # Very small values have issues with floating point accuracy. 7
         # orders of magnitude should be more than accurate enough.
+
         np.testing.assert_allclose(s_tr.data, l_tr.data,
                                    atol=1E-6 * s_tr.data.ptp())
 
@@ -104,12 +110,46 @@ def test_seismogram_extraction(syngine_client):
               "dt": 1.0, "kernelwidth": 6}
     _compare_streams(s_db, l_db, kwargs)
 
-    # Test force source.
-    if "displ_only" in s_db._client.filepath:
-        source = instaseis.ForceSource(
-            latitude=89.91, longitude=0.0, depth_in_m=12000,
-            f_r=1.23E10,
-            f_t=2.55E10,
-            f_p=1.73E10)
-        kwargs = {"source": source, "receiver": receiver}
+    # Force sources currently raise an error.
+    source = instaseis.ForceSource(
+        latitude=89.91, longitude=0.0, depth_in_m=12000,
+        f_r=1.23E10,
+        f_t=2.55E10,
+        f_p=1.73E10)
+    kwargs = {"source": source, "receiver": receiver}
+    with pytest.raises(ValueError) as e:
         _compare_streams(s_db, l_db, kwargs)
+
+    assert e.value.args[0] == (
+        "The Syngine Instaseis client does currently not "
+        "support force sources. You can still download "
+        "data from the Syngine service for force "
+        "sources manually.")
+
+    # Test less components and a latitude of 45 degrees to have the maximal
+    # effect of geocentric vs geographic coordinates.
+    source = instaseis.Source(
+        latitude=45.0, longitude=3.0, depth_in_m=0, m_rr=4.71e+17,
+        m_tt=3.81e+17, m_pp=-4.74e+17, m_rt=3.99e+17, m_rp=-8.05e+17,
+        m_tp=-1.23e+17)
+
+    receiver = instaseis.Receiver(latitude=-45.0, longitude=20.0,
+                                  depth_in_m=None)
+    kwargs = {"source": source, "receiver": receiver,
+              "components": ["Z", "N", "E", "R", "T"]}
+    _compare_streams(s_db, l_db, kwargs)
+
+
+def test_str_method(syngine_client):
+    str_repr = str(syngine_client)
+    # Replace version number string to not be dependent on a certain version.
+    str_repr = str_repr.replace("Syngine service version:  0.0.2", "XXX")
+
+    assert str_repr.startswith(
+        "SyngineInstaseisDB reciprocal Green's function Database (v7) "
+        "generated with these parameters:\n"
+        "Syngine model name:      'test'\n"
+        "XXX\n"
+        "\tcomponents           : vertical and horizontal\n"
+        "\tvelocity model       : prem_iso_light\n"
+        "\tattenuation          : False\n")


### PR DESCRIPTION
This PR adds an experimental Syngine backend to Instaseis. It probably still has some small issues like tiny time offsets and what not but I'll iron those out in a bit.

You can just use this instead of a normal instaseis db - just connect to `syngine://MODEL_NAME``,  e.g.:

```python
import instaseis

db = instaseis.open_db("syngine://ak135f")
```

This also works for the GUI and all other scripts and things using Instaseis.