### PR TITLE
db_info object passed to the travel time callback function.

### DIFF
--- a/advanced_server_configuration_example/launch_server.py
+++ b/advanced_server_configuration_example/launch_server.py
@@ -45,7 +45,7 @@ tau_model = TauPyModel(model="ak135")
 
 def get_travel_time(sourcelatitude, sourcelongitude, sourcedepthinmeters,
                     receiverlatitude, receiverlongitude,
-                    receiverdepthinmeters, phase_name):
+                    receiverdepthinmeters, phase_name, db_info):
     if receiverdepthinmeters:
         raise ValueError("This travel time implementation cannot calculate "
                          "buried receivers.")

--- a/doc/advanced_server_configuration.rst
+++ b/doc/advanced_server_configuration.rst
@@ -168,7 +168,8 @@ and receiver coordinates as well as a phase name and is supposed to return the
 travel time from source to receiver for that particular phase in seconds. The
 coordinates can be assumed to be geocentric and the calculations should happen
 in a spherical planet. Make sure to perform the calculations in the same model
-that has been used to calculate the databases.
+that has been used to calculate the databases. Please note that this callback
+function also receives the ``info`` attribute dictionary of the database.
 
 **Affected routes:**
 
@@ -182,9 +183,10 @@ that has been used to calculate the databases.
 
     def get_travel_time(sourcelatitude, sourcelongitude, sourcedepthinmeters,
                         receiverlatitude, receiverlongitude,
-                        receiverdepthinmeters, phase_name):
+                        receiverdepthinmeters, phase_name, db_info):
         ...
         return ttime
+
 
 **Parameters:**
 
@@ -202,6 +204,9 @@ that has been used to calculate the databases.
 
 * ``phase_name``: [*str*], case-sensitive phase name
 
+* ``db_info``: The ``info`` attribute dictionary of the used database. Useful
+  to calculate travel times for different models depending on the database.
+
 
 **Return Values:**
 
@@ -213,13 +218,13 @@ that has been used to calculate the databases.
 
 .. code-block:: python
 
-    >>> get_travel_time(0.0, 50.0, 300000, 0.0, 0.0, 0.0, "P")
+    >>> get_travel_time(0.0, 50.0, 300000, 0.0, 0.0, 0.0, "P", {})
     504.357
 
-    >>> get_travel_time(0.0, 50.0, 300000, 0.0, 0.0, 0.0, "Pdiff")
+    >>> get_travel_time(0.0, 50.0, 300000, 0.0, 0.0, 0.0, "Pdiff", {})
     None
 
-    >>> get_travel_time(0.0, 50.0, 300000, 0.0, 0.0, 0.0, "bogus")
+    >>> get_travel_time(0.0, 50.0, 300000, 0.0, 0.0, 0.0, "bogus", {})
     ValueError: Invalid phase name.
 
 

--- a/instaseis/server/instaseis_request.py
+++ b/instaseis/server/instaseis_request.py
@@ -300,7 +300,8 @@ class InstaseisTimeSeriesHandler(with_metaclass(ABCMeta,
                 receiverlatitude=receiver.latitude,
                 receiverlongitude=receiver.longitude,
                 receiverdepthinmeters=receiver.depth_in_m,
-                phase_name=phase)
+                phase_name=phase,
+                db_info=self.application.db.info)
         except ValueError as e:
             err_msg = str(e)
             if err_msg.lower().startswith("invalid phase name"):

--- a/instaseis/server/routes/travel_time.py
+++ b/instaseis/server/routes/travel_time.py
@@ -44,7 +44,8 @@ class TravelTimeHandler(InstaseisRequestHandler):
                     self.get_argument("receiverlongitude")),
                 receiverdepthinmeters=float(
                     self.get_argument("receiverdepthinmeters")),
-                phase_name=self.get_argument("phase"))
+                phase_name=self.get_argument("phase"),
+                db_info=self.application.db.info)
         except ValueError as e:
             err_msg = str(e)
             if err_msg.lower().startswith("invalid phase name"):

--- a/instaseis/tests/tornado_testing_fixtures.py
+++ b/instaseis/tests/tornado_testing_fixtures.py
@@ -198,7 +198,7 @@ def station_coordinates_mock_callback(networks, stations):
 
 def get_travel_time(sourcelatitude, sourcelongitude, sourcedepthinmeters,
                     receiverlatitude, receiverlongitude,
-                    receiverdepthinmeters, phase_name):
+                    receiverdepthinmeters, phase_name, db_info):
     """
     Fully working travel time callback implementation.
     """


### PR DESCRIPTION
@CTrabant this should enable you to fix iris-edu/irisws-syngine#24.

The `travel_time_callback` now has this signature (The `db_info` at the end is new):

```python
def get_travel_time(sourcelatitude, sourcelongitude, sourcedepthinmeters,
                    receiverlatitude, receiverlongitude,
                    receiverdepthinmeters, phase_name, db_info):
    
    # Calculate travel time either dependent on the model, or if that is
    # not enough, the directory.
    print(db_info.velocity_model)
    print(db_info.directory)

    ....

    return ttime
```

I'll merge this if you think this works for you. If you need something else let me know.