### PR TITLE
Custom STF and sourcewidth parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
-  - conda install --yes -c obspy nomkl obspy nose pytest flake8 sphinx h5py tornado click python=$TRAVIS_PYTHON_VERSION
+  - conda install --yes -c obspy nomkl obspy nose pytest flake8 sphinx h5py tornado click python=$TRAVIS_PYTHON_VERSION jsonschema
   # Don't install netcdf for Python 3.3 - the conda packages are just too old.
   - if [[ $TRAVIS_PYTHON_VERSION != '3.3' ]]; then conda install --yes netcdf4 ; fi
   # Only install the theme for Python 2.7 as it builds the docs.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -114,7 +114,7 @@ shared Fortran librarys - pull requests are welcome.
 * ``gfortran >= 4.7``
 * ``Python 2.7, 3.3, 3.4, or 3.5``
 * ``NumPy >= 1.7``
-* ``ObsPy >= 1.0.0``
+* ``ObsPy >= 1.0.1``
 * ``h5py``
 * ``future``
 * ``requests``
@@ -123,6 +123,7 @@ shared Fortran librarys - pull requests are welcome.
 * ``flake8``
 * ``pytest``
 * ``pytest-xdist``
+* ``jsonschema >= 2.4``
 * ``mock`` *(only for Python 2.x, otherwise part of the standard library)*
 
 The optional graphical user interface furthermore requires
@@ -162,7 +163,7 @@ Anaconda).
 
 .. code-block:: bash
 
-    $ conda install -c obspy obspy h5py future requests tornado flake8 pytest mock basemap pyqt pip
+    $ conda install -c obspy obspy h5py future requests tornado flake8 pytest mock basemap pyqt pip jsonschema
     $ pip install responses pyqtgraph pytest-xdist
 
 A possible complication arises **if you are running on a server without a

--- a/doc/routes/seismograms.rst
+++ b/doc/routes/seismograms.rst
@@ -82,6 +82,11 @@ Custom STF
 | ``kernelwidth``             | Integer  | False    | 12                          | Specify the width of the sinc kernel used for resampling to requested sample         |
 |                             |          |          |                             | interval in terms of the original sampling interval.                                 |
 +-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
+| ``sourcewidth``             | Integer  | False    | 15.0                        | Optionally convolve the seismograms with a Gaussian source time function (moment     |
+|                             |          |          |                             | rate) of approximately the given width in seconds. The origin time is assumed to be  |
+|                             |          |          |                             | the peak of the Gaussian. Must be larger than the database period. Must not be used  |
+|                             |          |          |                             | for a POST requests with a custom STF.                                               |
++-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
 | **Time Parameters**                                                                                                                                                    |
 +-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
 | ``origintime``              | Datetime | False    | 1900-01-01T00:00:00.000000Z | Specify the source origin time. This must be specified as an                         |

--- a/doc/routes/seismograms.rst
+++ b/doc/routes/seismograms.rst
@@ -1,5 +1,5 @@
-GET /seismograms
-^^^^^^^^^^^^^^^^
+GET/POST /seismograms
+^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
@@ -10,7 +10,10 @@ GET /seismograms
 Description
     Returns Instaseis seismograms. In addition to the functionality of the
     ``/seismograms_raw`` route this one has quite a couple of convenience
-    function and is suitable to be queried by any program able to use HTTP
+    function and is suitable to be queried by any program able to use HTTP.
+    It is possible to ``GET`` and ``POST`` to this route: ``GET`` will just
+    retrieve seismograms, ``POST`` allows one to upload a custom source time
+    function, see below for details.
 
 Content-Type
     * ``application/zip`` (if zipped SAC data is requested)
@@ -19,7 +22,7 @@ Content-Type
 Special Response Headers
     ``Instaseis-Mu``: This transports the mu of the model for the given
     seismogram which is needed for some finite source calculations. Please make
-    sure your proxy does not filter it.
+    sure your proxy, if any, does not filter it.
 
 Filetype
     Returns a ZIP archive with SAC files or MiniSEED files encoded with
@@ -32,6 +35,30 @@ Filetype
     * ``KT7``: The first seven letters of the AxiSEM version number used to generate the model. Prefixed with ``A``.
     * ``KT8``: The first seven letters of the Instaseis version number used to generate the seismogram. Prefixed with ``I``.
     * ``USER0``: The scale factor used to generate the waveforms.
+
+Custom STF
+    A custom source time function can be uploaded with ``POST``. The request
+    body in this case has to be a JSON file, the other parameters work as for
+    the ``GET`` case, except otherwise noted. The JSON file must be akin to the
+    following:
+
+    .. code-block:: JSON
+
+        {
+            "units": "moment_rate",
+            "relative_origin_time_in_sec": 5.0,
+            "sample_spacing_in_sec": 10.0,
+            "data": [0.0, 0.2, 0.5, 0.2, 0.0, 0.0, 0.0]
+        }
+
+    Keep in mind that what you are specifying is the moment rate, in seismology
+    oftentimes called the source time function, which is the only currently
+    supported ``unit``.  ``relative_origin_time_in_sec`` is the offset in
+    seconds from the first sample which should be considered the origin time of
+    the resulting seismogram (must be between 0 and 600 seconds).
+    ``sample_spacing_in_sec`` is the sample interval in seconds and ``data``
+    the actual data array. The exact units do not matter as it will be
+    normalized in any case.
 
 +-----------------------------+----------+----------+-----------------------------+--------------------------------------------------------------------------------------+
 | Parameter                   | Type     | Required | Default Value               | Description                                                                          |

--- a/instaseis/database_interfaces/base_instaseis_db.py
+++ b/instaseis/database_interfaces/base_instaseis_db.py
@@ -16,6 +16,7 @@ from __future__ import (absolute_import, division, print_function,
 from future.utils import with_metaclass
 
 from abc import ABCMeta, abstractmethod
+import math
 import warnings
 
 import numpy as np
@@ -307,7 +308,7 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
 
                 # Apply a 5 percent, at least 5 samples taper at the end.
                 # The first sample is guaranteed to be zero in any case.
-                tlen = max(0.05 * len(data[comp]), 5)
+                tlen = max(int(math.ceil(0.05 * len(data[comp]))), 5)
                 taper = np.ones_like(data[comp])
                 taper[-tlen:] = scipy.signal.hann(tlen * 2)[tlen:]
                 dataf = np.fft.rfft(taper * data[comp], n=self.info.nfft)

--- a/instaseis/server/app.py
+++ b/instaseis/server/app.py
@@ -82,7 +82,7 @@ def launch_io_loop(db_path, port, buffer_size_in_mb, quiet, log_level,
     """
     application = get_application()
     application.db = find_and_open_files(
-        db_path=db_path, buffer_size_in_mb=buffer_size_in_mb)
+        path=db_path, buffer_size_in_mb=buffer_size_in_mb)
     application.station_coordinates_callback = station_coordinates_callback
     application.event_info_callback = event_info_callback
 

--- a/instaseis/server/data/finite_source_schema.json
+++ b/instaseis/server/data/finite_source_schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://instaseis.net/source_time_function/1.0",
+  "type": "object",
+  "properties": {
+    "units": {
+      "id": "http://instaseis.net/source_time_function/1.0/units",
+      "type": "string",
+      "enum": ["moment_rate", "moment"]
+    },
+    "relative_origin_time_in_sec": {
+      "id": "http://instaseis.net/source_time_function/1.0/relative_origin_time_in_sec",
+      "type": "number"
+    },
+    "sample_spacing_in_sec": {
+      "id": "http://instaseis.net/source_time_function/1.0/sample_spacing_in_sec",
+      "type": "number",
+      "minimum": 0.00001,
+      "maximum": 200,
+      "exclusiveMaximum": false,
+      "exclusiveMinimum": false
+    },
+    "data": {
+      "id": "http://instaseis.net/source_time_function/1.0/data",
+      "type": "array",
+      "items": {
+        "id": "http://instaseis.net/source_time_function/1.0/data/values",
+        "type": "number"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "units",
+    "relative_origin_time_in_sec",
+    "sample_spacing_in_sec",
+    "data"
+  ]
+}

--- a/instaseis/server/data/finite_source_schema.json
+++ b/instaseis/server/data/finite_source_schema.json
@@ -6,7 +6,7 @@
     "units": {
       "id": "http://instaseis.net/source_time_function/1.0/units",
       "type": "string",
-      "enum": ["moment_rate", "moment"]
+      "enum": ["moment_rate"]
     },
     "relative_origin_time_in_sec": {
       "id": "http://instaseis.net/source_time_function/1.0/relative_origin_time_in_sec",

--- a/instaseis/server/data/finite_source_schema.json
+++ b/instaseis/server/data/finite_source_schema.json
@@ -4,15 +4,23 @@
   "type": "object",
   "properties": {
     "units": {
+      "title": "units",
+      "description": "The units of the given data array. Only moment_rate which seismologists also call the source time function is supported.",
       "id": "http://instaseis.net/source_time_function/1.0/units",
       "type": "string",
       "enum": ["moment_rate"]
     },
     "relative_origin_time_in_sec": {
+      "title": "Relative origin time in seconds",
+      "description": "Time in seconds from the first sample which should be considered the origin time of the final seismogram. The min/max restrictions are a bit arbitrary and aim to stabilize the algorithm.",
       "id": "http://instaseis.net/source_time_function/1.0/relative_origin_time_in_sec",
-      "type": "number"
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 600.0
     },
     "sample_spacing_in_sec": {
+      "title": "Sample spacing in seconds (delta)",
+      "description": "The sample interval of the given data.",
       "id": "http://instaseis.net/source_time_function/1.0/sample_spacing_in_sec",
       "type": "number",
       "minimum": 0.00001,
@@ -21,12 +29,16 @@
       "exclusiveMinimum": false
     },
     "data": {
+      "title": "Data",
+      "description": "The actual data array.",
       "id": "http://instaseis.net/source_time_function/1.0/data",
       "type": "array",
       "items": {
         "id": "http://instaseis.net/source_time_function/1.0/data/values",
         "type": "number"
-      }
+      },
+      "minItems": 5,
+      "maxItems": 10000
     }
   },
   "additionalProperties": false,

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -138,9 +138,8 @@ def _parse_validate_and_resample_stf(request, db_info, callback):
 
     missing_length = db_info.length - (
         len(j["data"]) - 1) * j["sample_spacing_in_sec"]
-    missing_samples = int(missing_length / j["sample_spacing_in_sec"]) + 1
-    if missing_samples < 0:
-        missing_samples = 1
+    missing_samples = max(int(missing_length / j["sample_spacing_in_sec"]) + 1,
+                          0)
 
     # Add a buffer of 20 samples at the beginning and at the end.
     data = np.concatenate([

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -23,7 +23,7 @@ import tornado.web
 
 from ... import Source, ForceSource, Receiver
 from ..util import run_async, IOQueue, _validtimesetting, \
-    _validate_and_write_waveforms
+    _validate_and_write_waveforms, get_gaussian_source_time_function
 from ..instaseis_request import InstaseisTimeSeriesHandler
 
 
@@ -499,6 +499,19 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
         # Parse the arguments. This will also perform a number of sanity
         # checks.
         args = self.parse_arguments()
+
+        # We'll piggyback the sourcewidth on the implementation of the custom
+        # STF. This is not super clean to be honest but its simple and it
+        # works.
+        if args.sourcewidth:
+            dt = self.application.db.info.dt
+            offset, data = get_gaussian_source_time_function(
+                source_width=args.sourcewidth, dt=dt)
+            custom_stf = {
+                "relative_origin_time_in_sec": offset,
+                "sample_spacing_in_sec": dt,
+                "data": data
+            }
 
         if args.eventid is not None:
             # It has to be extracted here to get the origin time which is

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -17,10 +17,11 @@ from jsonschema import validate as json_validate
 from jsonschema import ValidationError as JSONValidationError
 import numpy as np
 import obspy
+from obspy.signal.interpolation import lanczos_interpolation
 import tornado.gen
 import tornado.web
 
-from ... import Source, ForceSource, Receiver, lanczos
+from ... import Source, ForceSource, Receiver
 from ..util import run_async, IOQueue, _validtimesetting, \
     _validate_and_write_waveforms
 from ..instaseis_request import InstaseisTimeSeriesHandler
@@ -67,7 +68,7 @@ def _get_seismogram(db, source, receiver, components, units, dt, kernelwidth,
             kind=units, remove_source_shift=False,
             reconvolve_stf=reconvolve_stf, return_obspy_stream=True, dt=dt,
             kernelwidth=kernelwidth)
-    except Exception as e:
+    except Exception:
         msg = ("Could not extract seismogram. Make sure, the components "
                "are valid, and the depth settings are correct.")
         callback((tornado.web.HTTPError(400, log_message=msg, reason=msg),
@@ -139,7 +140,7 @@ def _parse_validate_and_resample_stf(request, db_info, callback):
         np.zeros(20), j["data"], np.zeros(missing_samples + 20)])
 
     # Resample it using sinc reconstruction.
-    data = lanczos.lanczos_interpolation(
+    data = lanczos_interpolation(
         data,
         # Account for the additional samples at the beginning.
         old_start=-20 * j["sample_spacing_in_sec"],

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -396,6 +396,7 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
         if custom_stf:
             source.sliprate = custom_stf["data"]
             source.dt = self.application.db.info.dt
+            source.time_shift = -custom_stf["relative_origin_time_in_sec"]
 
         return source
 

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -125,14 +125,20 @@ def _parse_validate_and_resample_stf(request, db_info, callback):
     j["data"] = np.array(j["data"], np.float64)
 
     # A couple more custom validations.
+    message = None
+
+    # Make sure its not all zeros.
+    if np.abs(j["data"]).max() < 1E-20:
+        message = ("All zero (or nearly all zero) source time functions don't "
+                   "make any sense.")
+
     # The data must begin and end with zero. The user is responsible for the
     # tapering.
-    message = None
     if j["data"][0] != 0.0 or j["data"][-1] != 0.0:
         message = "Must begin and end with zero."
 
     if message:
-        msg = "STF Data did not validate: %s" % message
+        msg = "STF data did not validate: %s" % message
         callback(tornado.web.HTTPError(400, log_message=msg, reason=msg))
         return
 

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -114,6 +114,13 @@ def _parse_validate_and_resample_stf(request, db_info, callback):
         callback(tornado.web.HTTPError(400, log_message=msg, reason=msg))
         return
 
+    # Make sure the sampling rate is ok.
+    if j["sample_spacing_in_sec"] < db_info.dt:
+        msg = "'sample_spacing_in_sec' in the JSON file must not be smaller " \
+              "than the database dt [%.3f seconds]." % db_info.dt
+        callback(tornado.web.HTTPError(400, log_message=msg, reason=msg))
+        return
+
     # Convert to numpy array.
     j["data"] = np.array(j["data"], np.float64)
 

--- a/instaseis/source.py
+++ b/instaseis/source.py
@@ -712,6 +712,7 @@ class ForceSource(SourceOrReceiver):
         peak of the source time function used to generate the database.
         If you reconvolve with another source time function this time is
         the time of the first sample of the final seismogram.
+    :param sliprate: normalized source time function (sliprate)
 
 
     >>> import instaseis
@@ -726,12 +727,13 @@ class ForceSource(SourceOrReceiver):
         Fp        :   0.00e+00 N
     """
     def __init__(self, latitude, longitude, depth_in_m=None, f_r=0., f_t=0.,
-                 f_p=0., origin_time=obspy.UTCDateTime(0)):
+                 f_p=0., origin_time=obspy.UTCDateTime(0), sliprate=None):
         super(ForceSource, self).__init__(latitude, longitude, depth_in_m)
         self.f_r = f_r
         self.f_t = f_t
         self.f_p = f_p
         self.origin_time = origin_time
+        self.sliprate = sliprate
 
     @property
     def force_tpr(self):

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -4836,6 +4836,16 @@ def test_error_handling_custom_stf(all_clients):
     assert request.reason == (
         "STF Data did not validate: Must begin and end with zero.")
 
+    # The sample spacing must not be smaller than the database sampling.
+    body = copy.deepcopy(valid_json)
+    body["sample_spacing_in_sec"] = 10.0
+    request = client.fetch(_assemble_url('seismograms'),
+                           method="POST", body=json.dumps(body))
+    assert request.code == 400
+    assert request.reason == (
+        "'sample_spacing_in_sec' in the JSON file must not be smaller than "
+        "the database dt [24.725 seconds].")
+
 
 def test_custom_stf(all_clients):
     """

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -4969,7 +4969,6 @@ def test_sourcewidth_parameter(all_clients):
         "format": "miniseed",
         "sourcemomenttensor": "100000,200000,300000,400000,500000,600000"}
 
-
     r = client.fetch(_assemble_url('seismograms', sourcewidth=1.0,
                                    **basic_parameters))
     assert r.code == 400

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -4790,7 +4790,7 @@ def test_error_handling_custom_stf(all_clients):
     }
 
     # Couple more wrong ones.
-    body = copy.copy(valid_json)
+    body = copy.deepcopy(valid_json)
     body["units"] = "random"
     request = client.fetch(_assemble_url('seismograms'),
                            method="POST", body=json.dumps(body))
@@ -4800,7 +4800,7 @@ def test_error_handling_custom_stf(all_clients):
         "Validation Error in JSON file: 'random' is not one of "
         "['moment_rate', 'moment']")
 
-    body = copy.copy(valid_json)
+    body = copy.deepcopy(valid_json)
     body["sample_spacing_in_sec"] = -0.1
     request = client.fetch(_assemble_url('seismograms'),
                            method="POST", body=json.dumps(body))
@@ -4810,7 +4810,7 @@ def test_error_handling_custom_stf(all_clients):
         "Validation Error in JSON file: -0.1 is less than the minimum of "
         "1e-05")
 
-    body = copy.copy(valid_json)
+    body = copy.deepcopy(valid_json)
     body["data"].append("hello")
     request = client.fetch(_assemble_url('seismograms'),
                            method="POST", body=json.dumps(body))

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -4997,8 +4997,8 @@ def test_sourcewidth_parameter(all_clients):
     assert r.code == 200
     st = obspy.read(r.buffer)
 
-    r = client.fetch(_assemble_url('seismograms', **basic_parameters,
-                                   sourcewidth=200.0))
+    r = client.fetch(_assemble_url('seismograms', sourcewidth=200.0,
+                                   **basic_parameters))
     st_re = obspy.read(r.buffer)
 
     for comp in ["Z", "N", "E", "R", "T"]:

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -4834,7 +4834,7 @@ def test_error_handling_custom_stf(all_clients):
                            method="POST", body=json.dumps(body))
     assert request.code == 400
     assert request.reason == (
-        "STF Data did not validate: Must begin and end with zero.")
+        "STF data did not validate: Must begin and end with zero.")
 
     # The sample spacing must not be smaller than the database sampling.
     body = copy.deepcopy(valid_json)
@@ -4845,6 +4845,15 @@ def test_error_handling_custom_stf(all_clients):
     assert request.reason == (
         "'sample_spacing_in_sec' in the JSON file must not be smaller than "
         "the database dt [24.725 seconds].")
+
+    # Should raise for an all zeros array.
+    body = copy.deepcopy(valid_json)
+    body["data"] = [0, 0, 0, 0, 0, 0]
+    request = client.fetch(_assemble_url('seismograms'),
+                           method="POST", body=json.dumps(body))
+    assert request.code == 400
+    assert ("All zero (or nearly all zero) source time functions don't "
+            "make any sense.") in request.reason
 
 
 def test_custom_stf(all_clients):

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -4855,3 +4855,4 @@ def test_custom_stf(all_clients):
                            method="POST", body=json.dumps(body))
     assert request.code == 200
     st_server = obspy.read(request.buffer)
+    st_server

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,8 @@ INSTALL_REQUIRES = ["h5py",
                     "tornado>=4.0.0",
                     "flake8>=2",
                     "pytest",
-                    "responses"]
+                    "responses",
+                    "jsonschema >= 2.4.0"]
 
 EXTRAS_REQUIRE = {
     'tests': ['click', 'netCDF4', 'pytest-xdist']


### PR DESCRIPTION
Long promised and finally there: the ability to convolve with a custom STF and the `sourcewidth` parameter!

Manually pinging you all as I'm not sure if you follow the Instaseis issues. @martinvandriel, @sstaehler, @tnissen, @alexhutko, @CTrabant

You can now send a POST request to the `/seismograms` route and attach a JSON file akin to the following:

```json
{
    "units": "moment_rate",
    "relative_origin_time_in_sec": 5.0,
    "sample_spacing_in_sec": 10.0,
    "data": [0.0, 0.2, 0.5, 0.2, 0.0, 0.0, 0.0]
}
```

This is enforced via a JSON schema so the `jsonschema` package is now an additional dependency - this should not be a big issue as its also a dependency of Jupyter/IPython which most people will have installed in any case:

https://github.com/krischer/instaseis/blob/custom_stf/instaseis/server/data/finite_source_schema.json

* I chose to only support moment rate input as adding support for passing the actual moment would complicate the logic for some cases quite a bit and I don't see a big use for this to be honest. Its still in the file because I think its nice to be explicit.
* The limits in the schema are somewhat arbitrary but help to stabilize the logic and save us from people requesting data for completely bonkers source time functions.
* The sample interval cannot be smaller than the dt of the database - it will raise otherwise. I don't want to deal with aliasing filtering and things like causality. I don't think there is a one size fits all solution for that so we better just avoid it.
* Larger dts will be upsampled (with lanczos) to the sampling interval of the database.
* They are normalized by dividing through the integral of the absolute values of the data. This is wrong for STFs that have zero crossings but I don't really know how to solve that. Ideas? 


Additionally the `/seismograms` route now has a `sourcewidth` parameter which, if given, will reconvolve the seismograms with a Gaussian with approximately that width in seconds. This is twice the half duration as its used in SPECFEM or the GCMT catalog.

I think it all works but its really kind of hard to tell as we now have so many different parameters so it would be great if somebody could actually **review and test** this PR. IMHO this is ready to merge but please have look. In particular to things like the time settings.

Example usage: https://gist.github.com/krischer/caab4d43107f8725a33709a159ca987b

![screen shot 2016-04-06 at 19 17 44](https://cloud.githubusercontent.com/assets/800487/14325997/44f199ac-fc2c-11e5-80bf-0d6459636031.png)
