### PR TITLE
Multiple phases for the /ttimes route

### DIFF
--- a/doc/routes/ttimes.rst
+++ b/doc/routes/ttimes.rst
@@ -7,7 +7,9 @@ GET /ttimes
     :doc:`../advanced_server_configuration` for details.
 
 Description
-    Get theoretical arrival times through a 1D Earth model if the server has been configured with that capability.
+    Get theoretical arrival times through a 1D Earth model if the server has been configured with that capability. For each phase name
+    it will only return a single time - multiple arrivals of the same phase are thus not visible. The exact returned arrival depends
+    on the used callback function - a sensible choice is the first arriving one.
 
 Content-Type
     application/json; charset=UTF-8
@@ -16,7 +18,11 @@ Example Response
     .. code-block:: json
 
         {
-            "travel_time": 570.8677703798731
+            "travel_times": {
+                "P": 504.357,
+                "PP": 622.559,
+                "sPKiKP": 1090.081
+            }
         }
 
 +--------------------------+----------+----------+--------------------------------------------------------------------------------------------------------------+
@@ -35,5 +41,5 @@ Example Response
 | ``receiverdepthinmeters``| Float    | True     | Depth of the receiver in meters. Many implementations will raise an error if this is not zero as they cannot |
 |                          |          |          | deal with buried receivers.                                                                                  |
 +--------------------------+----------+----------+--------------------------------------------------------------------------------------------------------------+
-| ``phase``                | Float    | True     | The phase name. Depending on the travel time implementation this can be very flexible.                       |
+| ``phases``               | Float    | True     | Comma separated phase names. Depending on the travel time implementation this can be very flexible.          |
 +--------------------------+----------+----------+--------------------------------------------------------------------------------------------------------------+

--- a/instaseis/server/routes/travel_time.py
+++ b/instaseis/server/routes/travel_time.py
@@ -7,6 +7,8 @@
     GNU Lesser General Public License, Version 3 [non-commercial/academic use]
     (http://www.gnu.org/copyleft/lgpl.html)
 """
+import collections
+
 import tornado.web
 
 from ..instaseis_request import InstaseisRequestHandler
@@ -22,7 +24,7 @@ class TravelTimeHandler(InstaseisRequestHandler):
         required_parameters = (
             "sourcelatitude", "sourcelongitude", "sourcedepthinmeters",
             "receiverlatitude", "receiverlongitude", "receiverdepthinmeters",
-            "phase")
+            "phases")
 
         missing_parameters = sorted([_i for _i in required_parameters
                                      if _i not in self.request.arguments])
@@ -32,30 +34,39 @@ class TravelTimeHandler(InstaseisRequestHandler):
             raise tornado.web.HTTPError(
                 400, log_message=msg, reason=msg)
 
-        try:
-            tt = self.application.travel_time_callback(
-                sourcelatitude=float(self.get_argument("sourcelatitude")),
-                sourcelongitude=float(self.get_argument("sourcelongitude")),
-                sourcedepthinmeters=float(
-                    self.get_argument("sourcedepthinmeters")),
-                receiverlatitude=float(
-                    self.get_argument("receiverlatitude")),
-                receiverlongitude=float(
-                    self.get_argument("receiverlongitude")),
-                receiverdepthinmeters=float(
-                    self.get_argument("receiverdepthinmeters")),
-                phase_name=self.get_argument("phase"),
-                db_info=self.application.db.info)
-        except ValueError as e:
-            err_msg = str(e)
-            if err_msg.lower().startswith("invalid phase name"):
-                msg = "Invalid phase name."
-            else:
-                msg = "Failed to calculate travel time due to: %s" % str(e)
-            raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+        # Preserve order.
+        all_phases = collections.OrderedDict()
 
-        if tt is None:
-            msg = "No ray for the given geometry and phase found."
+        for p in self.get_argument("phases").split(","):
+            try:
+                tt = self.application.travel_time_callback(
+                    sourcelatitude=float(
+                        self.get_argument("sourcelatitude")),
+                    sourcelongitude=float(
+                        self.get_argument("sourcelongitude")),
+                    sourcedepthinmeters=float(
+                        self.get_argument("sourcedepthinmeters")),
+                    receiverlatitude=float(
+                        self.get_argument("receiverlatitude")),
+                    receiverlongitude=float(
+                        self.get_argument("receiverlongitude")),
+                    receiverdepthinmeters=float(
+                        self.get_argument("receiverdepthinmeters")),
+                    phase_name=p,
+                    db_info=self.application.db.info)
+                if tt:
+                    all_phases[p] = tt
+            except ValueError as e:
+                err_msg = str(e)
+                if err_msg.lower().startswith("invalid phase name"):
+                    msg = "Invalid phase name '%s'." % p
+                else:
+                    msg = "Failed to calculate travel time due to: %s" % str(e)
+                raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+
+        if not all_phases:
+            msg = \
+                "No ray for the given geometry and any of the phases found."
             raise tornado.web.HTTPError(404, log_message=msg, reason=msg)
 
-        self.write({"travel_time": tt})
+        self.write({"travel_times": all_phases})


### PR DESCRIPTION
This PR enables the `/ttimes` route to serve multiple phases in a single request. The required callback function did not change but the `/ttimes` route changed slightly. This should be ok as I'm not aware of any implementation publicly using it. Instead of `phase` the argument name is now `phases`, e.g.

```
ROOT/ttimes?sourcelatitude=0&sourcelongitude=0&
  sourcedepthinmeters=300000&receiverlatitude=0&receiverlongitude=50&
  receiverdepthinmeters=0&phases=sPKiKP,P,PP,Sdiff
```

Will return the following JSON:

```json
{
    "travel_times": {
        "P": 504.357,
        "PP": 622.559,
        "sPKiKP": 1090.081
    }
}
```

It is only capable of returning a single time per phase. The callback function must thus deal with multiple arrivals of the same phase and choose which one to return.

@martinvandriel Can you check with your folks if that is acceptable?