### PR TITLE
Sac dist header fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
-  - conda install --yes -c conda-forge nomkl obspy nose pytest sphinx h5py tornado click python=$TRAVIS_PYTHON_VERSION jsonschema netcdf4
+  - conda install --yes -c conda-forge nomkl obspy nose pytest sphinx h5py tornado click python=$TRAVIS_PYTHON_VERSION jsonschema netcdf4 geographiclib
   # Always install latest flake8.
   - pip install flake8
   # Only install the theme for Python 2.7 as it builds the docs.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -134,6 +134,7 @@ shared Fortran librarys - pull requests are welcome.
 * ``requests``
 * ``tornado``
 * ``jsonschema >= 2.4``
+* ``geographiclib``
 
 To run the tests, please also install:
 

--- a/instaseis/server/util.py
+++ b/instaseis/server/util.py
@@ -13,6 +13,10 @@ import re
 import functools
 import threading
 
+# This is needed for the gps2dist_azimuth() function to always be stable. We
+# thus enforce an import here.
+import geographiclib  # noqa
+
 import numpy as np
 import obspy
 from obspy.geodetics import gps2dist_azimuth, locations2degrees
@@ -22,6 +26,7 @@ import tornado.web
 from .. import ForceSource, FiniteSource
 from ..helpers import geocentric_to_elliptic_latitude
 from .. import __version__
+
 
 # Valid phase offset pattern including capture groups.
 PHASE_OFFSET_PATTERN = re.compile(r"(^[A-Za-z0-9^]+)([\+-])([\deE\.\-\+]+$)")

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ INSTALL_REQUIRES = ["h5py",
                     "future",
                     "tornado>=4.0.0",
                     "requests",
+                    "geographiclib",
                     "jsonschema >= 2.4.0"]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
Fixed by forcing the availability of `geographiclib`. Otherwise the vincenty formula  is unstable in certain cases and has wrong result. Fixes #55.

See https://github.com/iris-edu/irisws-syngine/issues/38