### PR TITLE
Exact definition of M0

### DIFF
--- a/instaseis/source.py
+++ b/instaseis/source.py
@@ -65,7 +65,7 @@ def moment2magnitude(M0):  # NOQA
     :return Mw: moment magnitude
     :type Mw: float
     """
-    return 2.0 / 3.0 * np.log10(M0) - 6.0
+    return 2.0 / 3.0 * (np.log10(M0) - 9.1)
 
 
 def magnitude2moment(Mw):  # NOQA
@@ -77,7 +77,7 @@ def magnitude2moment(Mw):  # NOQA
     :return M0: seismic moment in Nm
     :type M0: float
     """
-    return 10.0 ** ((Mw + 6.0) / 2.0 * 3.0)
+    return 10.0 ** ((Mw / 2.0 * 3.0 + 9.1))
 
 
 def fault_vectors_lmn(strike, dip, rake):


### PR DESCRIPTION
To quote the NMSOP, chapter 3, p.125, eq. 3.68:

Mw = (log M0 – 9.1)/1.5 = (2/3) (log M0 – 9.1)       

Formula  (3.68)  is  now  the  IASPEI  (2005  and  2013)  accepted  standard  form of  writing  the moment  magnitude  formula.  It  avoids  rounding  errors  and  an  ambiguity  that  arises  if  multiplication is performed prior to subtraction, which in a certain percentage of cases leads to  Mw  being  different  according  to  whether  the  moment  is  expressed  in  CGS  or  SI  units  
(Utsu, 2002, and  IS 3.3).