### PR TITLE
Better error message when using finite source in wrong method

### DIFF
--- a/instaseis/database_interfaces/base_instaseis_db.py
+++ b/instaseis/database_interfaces/base_instaseis_db.py
@@ -27,7 +27,7 @@ from obspy.signal.interpolation import lanczos_interpolation
 from scipy.integrate import cumtrapz
 import scipy.signal
 
-from ..source import Source, ForceSource, Receiver
+from ..source import Source, ForceSource, Receiver, FiniteSource
 from ..helpers import get_band_code, sizeof_fmt, rfftfreq
 
 
@@ -595,6 +595,11 @@ class BaseInstaseisDB(with_metaclass(ABCMeta)):
                     "seconds. You must not pass a 'dt' larger than that as "
                     "that would be a downsampling operation which Instaseis "
                     "does not do." % self.info.dt)
+
+        if isinstance(source, FiniteSource):
+            raise TypeError(
+                "Please use the `get_seismograms_finite_source()` method to "
+                "compute seisomgrams with finite sources.")
 
         # Attempt to parse them if the types are not correct.
         if not isinstance(source, Source) and \

--- a/instaseis/tests/test_instaseis.py
+++ b/instaseis/tests/test_instaseis.py
@@ -26,7 +26,7 @@ from instaseis import InstaseisError, InstaseisNotFoundError
 from instaseis.database_interfaces import find_and_open_files
 from instaseis.database_interfaces.base_instaseis_db import \
     _get_seismogram_times
-from instaseis import Source, Receiver, ForceSource
+from instaseis import Source, Receiver, ForceSource, FiniteSource
 from instaseis.helpers import (get_band_code, elliptic_to_geocentric_latitude,
                                geocentric_to_elliptic_latitude, sizeof_fmt)
 
@@ -1930,3 +1930,20 @@ def test_no_downsampling(bwd_db):
         "The database is sampled with a sample spacing of 24.725 seconds. You "
         "must not pass a 'dt' larger than that as that would be a "
         "downsampling operation which Instaseis does not do.")
+
+
+@pytest.mark.parametrize("db", BW_DISPL_DBS)
+def test_exception_when_using_a_finite_source_instead_of_a_normal_source(db):
+    """
+    Tests that a sensible error message is raised.
+    """
+    db = find_and_open_files(db)
+    src = FiniteSource()
+    rec = Receiver(latitude=10., longitude=20.)
+
+    with pytest.raises(TypeError) as err:
+        db.get_seismograms(source=src, receiver=rec)
+
+    assert err.value.args[0] == (
+        "Please use the `get_seismograms_finite_source()` method to compute "
+        "seisomgrams with finite sources.")


### PR DESCRIPTION
See #62 - with this PR it uses a helpful error message.