### PR TITLE
Clarify direction of r, theta, phi unit vectors

### DIFF
--- a/doc/source.rst
+++ b/doc/source.rst
@@ -28,7 +28,7 @@ or double couple sources, :class:`~instaseis.source.ForceSource` object are
     The directions of r, theta, and phi are defined according to the standard
     `spherical coordinate system definition <https://en.wikipedia.org/wiki/Spherical_coordinate_system>`_
     used in physics, which is: r positive outward, theta positive downward, and
-    phi positive counter_clockwise.
+    phi positive counter-clockwise.
 
 .. contents::
     :local:

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -25,6 +25,10 @@ or double couple sources, :class:`~instaseis.source.ForceSource` object are
        coordinates are assumed to be WGS84 and will be converted so the
        source/receiver objects are again in geocentric coordinates.
 
+    The directions of r, theta, and phi are defined according to the standard
+    `spherical coordinate system definition <https://en.wikipedia.org/wiki/Spherical_coordinate_system>`_
+    used in physics, which is: r positive outward, theta positive downward, and
+    phi positive counter_clockwise.
 
 .. contents::
     :local:

--- a/instaseis/source.py
+++ b/instaseis/source.py
@@ -698,18 +698,6 @@ class ForceSource(SourceOrReceiver, SourceTimeFunction):
         the time of the first sample of the final seismogram.
     :param sliprate: normalized source time function (sliprate)
 
-    .. note::
-    
-    The directions for r, theta, and phi are as given in Figure 1 of
-    Nissen-Meyer *et al.* (2008).
-    
-    .. list-table::
-
-    * - | Nissen-Meyer, Tarje, Alexandre Fournier, and F. A. Dahlen (2008)
-        | **A 2-D spectral-element method for computing spherical-earth
-        | seismograms—II. Waves in solid–fluid media.**
-        | *Geophysical Journal International* 174 (3): 873–888.
-        | https://doi.org/10.1111/j.1365-246X.2008.03813.x
 
     >>> import instaseis
     >>> source = instaseis.ForceSource(latitude=12.34, longitude=12.34,

--- a/instaseis/source.py
+++ b/instaseis/source.py
@@ -698,6 +698,18 @@ class ForceSource(SourceOrReceiver, SourceTimeFunction):
         the time of the first sample of the final seismogram.
     :param sliprate: normalized source time function (sliprate)
 
+    .. note::
+    
+    The directions for r, theta, and phi are as given in Figure 1 of
+    Nissen-Meyer *et al.* (2008).
+    
+    .. list-table::
+
+    * - | Nissen-Meyer, Tarje, Alexandre Fournier, and F. A. Dahlen (2008)
+        | **A 2-D spectral-element method for computing spherical-earth
+        | seismograms—II. Waves in solid–fluid media.**
+        | *Geophysical Journal International* 174 (3): 873–888.
+        | https://doi.org/10.1111/j.1365-246X.2008.03813.x
 
     >>> import instaseis
     >>> source = instaseis.ForceSource(latitude=12.34, longitude=12.34,


### PR DESCRIPTION
In trying to create a `ForceSource` object, I was unclear of the direction of the r, theta, and phi hat vectors (mainly the latter two). I found a definition in [Nissen-Meyer *et al.* (2008)](https://academic.oup.com/gji/article/174/3/873/604222), Figure 1:

![Screen Shot 2020-06-16 at 4 00 25 PM](https://user-images.githubusercontent.com/38269494/84832458-86620400-afea-11ea-95e0-152e5db3e867.png)

This suggests that — relative to someone standing on Earth's surface — r is positive upwards, theta is positive to the south, and phi is positive to the east. Is this the correct definition? If so, I would kindly suggest including a reference to the paper (as implemented in this PR) for some clarity.

Thanks!

(The RST formatting might be wrong here, I was just guessing.)