### PR TITLE
Added support for output SAC headers with geocentric coordinate system

### DIFF
--- a/instaseis/server/routes/finite_source.py
+++ b/instaseis/server/routes/finite_source.py
@@ -66,7 +66,8 @@ def _get_finite_source(
     :param time_of_first_sample: The time of the first sample.
     :param format: The output format. Either "miniseed" or "saczip".
     :param label: Prefix for the filename within the SAC zip file.
-    ;param sacheader: Indicates if the SAC header should be populated with geodetic or geocentric latitudes.
+    :param sacheader: Indicates if the SAC header should be populated with
+        geodetic or geocentric latitudes.
     """
     try:
         st = db.get_seismograms_finite_source(

--- a/instaseis/server/routes/finite_source.py
+++ b/instaseis/server/routes/finite_source.py
@@ -47,6 +47,7 @@ def _get_finite_source(
     time_of_first_sample,
     format,
     label,
+    sacheader,
 ):
     """
     Extract a seismogram from the passed db and write it either to a MiniSEED
@@ -65,6 +66,7 @@ def _get_finite_source(
     :param time_of_first_sample: The time of the first sample.
     :param format: The output format. Either "miniseed" or "saczip".
     :param label: Prefix for the filename within the SAC zip file.
+    ;param sacheader: Indicates if the SAC header should be populated with geodetic or geocentric latitudes.
     """
     try:
         st = db.get_seismograms_finite_source(
@@ -125,6 +127,7 @@ def _get_finite_source(
         db=db,
         label=label,
         format=format,
+        sacheader=sacheader,
     )
 
 
@@ -272,6 +275,7 @@ class FiniteSourceSeismogramsHandler(InstaseisTimeSeriesHandler):
         "network": {"type": str},
         "station": {"type": str},
         "format": {"type": str, "default": "saczip"},
+        "sacheader": {"type": str, "default": "geodetic"},
     }
 
     default_label = "instaseis_finite_source_seismogram"
@@ -467,6 +471,7 @@ class FiniteSourceSeismogramsHandler(InstaseisTimeSeriesHandler):
                 time_of_first_sample=time_of_first_sample,
                 format=args.format,
                 label=args.label,
+                sacheader=args.sacheader,
             )
 
             # Check connection once again.

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -36,6 +36,7 @@ def _get_greens(
     endtime,
     format,
     label,
+    sacheader,
 ):
     """
     Extract a Green's function from the passed db and write it either to a
@@ -52,6 +53,7 @@ def _get_greens(
     :param endtime: The desired end time of the seismogram.
     :param format: The output format. Either "miniseed" or "saczip".
     :param label: Prefix for the filename within the SAC zip file.
+    ;param sacheader: Indicates if the SAC header should be populated with geodetic or geocentric latitudes.
     """
     try:
         st = db.get_greens_function(
@@ -99,6 +101,7 @@ def _get_greens(
         db=db,
         label=label,
         format=format,
+        sacheader=sacheader,
     )
 
 
@@ -123,6 +126,7 @@ class GreensFunctionHandler(InstaseisTimeSeriesHandler):
             "format": "Datetime String/Float/Phase+-Offset",
         },
         "format": {"type": str, "default": "saczip"},
+        "sacheader": {"type": str, "default": "geodetic"},
     }
 
     default_label = "instaseis_greens_function"
@@ -232,6 +236,7 @@ class GreensFunctionHandler(InstaseisTimeSeriesHandler):
             endtime=endtime,
             format=args.format,
             label=args.label,
+            sacheader=args.sacheader,
         )
 
         # If an exception is returned from the task, re-raise it here.

--- a/instaseis/server/routes/greens.py
+++ b/instaseis/server/routes/greens.py
@@ -53,7 +53,8 @@ def _get_greens(
     :param endtime: The desired end time of the seismogram.
     :param format: The output format. Either "miniseed" or "saczip".
     :param label: Prefix for the filename within the SAC zip file.
-    ;param sacheader: Indicates if the SAC header should be populated with geodetic or geocentric latitudes.
+    :param sacheader: Indicates if the SAC header should be populated with
+        geodetic or geocentric latitudes.
     """
     try:
         st = db.get_greens_function(

--- a/instaseis/server/routes/seismograms.py
+++ b/instaseis/server/routes/seismograms.py
@@ -60,8 +60,9 @@ def _get_seismogram(
     starttime,
     endtime,
     scale,
-    format,
+    sacheader,
     label,
+    format,
 ):
     """
     Extract a seismogram from the passed db and write it either to a MiniSEED
@@ -116,6 +117,7 @@ def _get_seismogram(
         db=db,
         label=label,
         format=format,
+        sacheader=sacheader,
     )
 
 
@@ -292,6 +294,7 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
         "network": {"type": str},
         "station": {"type": str},
         "format": {"type": str, "default": "saczip"},
+        "sacheader": {"type": str, "default": "geodetic"},
     }
 
     default_label = "instaseis_seismogram"
@@ -728,6 +731,7 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
                     scale=args.scale,
                     format=args.format,
                     label=args.label,
+                    sacheader=args.sacheader,
                 )
             else:
                 response, mu = _get_seismogram(
@@ -743,6 +747,7 @@ class SeismogramsHandler(InstaseisTimeSeriesHandler):
                     scale=args.scale,
                     format=args.format,
                     label=args.label,
+                    sacheader=args.sacheader,
                 )
 
             # Check connection once again.

--- a/instaseis/server/routes/seismograms_raw.py
+++ b/instaseis/server/routes/seismograms_raw.py
@@ -117,6 +117,7 @@ class RawSeismogramsHandler(InstaseisTimeSeriesHandler):
         "locationcode": {"type": str},
     }
     default_label = "instaseis_seismogram"
+    default_sacheader = "geodetic"
 
     def validate_parameters(self, args):
         pass

--- a/instaseis/server/util.py
+++ b/instaseis/server/util.py
@@ -93,7 +93,16 @@ def _format_utc_datetime(dt):
 
 
 def _validate_and_write_waveforms(
-    st, starttime, endtime, scale, source, receiver, db, label, format, sacheader='geodetic'
+    st,
+    starttime,
+    endtime,
+    scale,
+    source,
+    receiver,
+    db,
+    label,
+    format,
+    sacheader="geodetic",
 ):
     if not label:
         label = ""
@@ -152,9 +161,10 @@ def _validate_and_write_waveforms(
         for tr in st:
             # Write SAC headers.
             tr.stats.sac = obspy.core.AttribDict()
-            # Write WGS84 coordinates to the SAC files (for the Earth models only).
+            # Write WGS84 coordinates to the SAC files (for the Earth models
+            # only).
             tr.stats.sac.stla = receiver.latitude
-            if sacheader == 'geodetic':
+            if sacheader == "geodetic":
                 tr.stats.sac.stla = geocentric_to_elliptic_latitude(
                     receiver.latitude
                 )
@@ -163,7 +173,7 @@ def _validate_and_write_waveforms(
             tr.stats.sac.stel = 0.0
             if isinstance(source, FiniteSource):
                 tr.stats.sac.evla = source.hypocenter_latitude
-                if sacheader == 'geodetic':
+                if sacheader == "geodetic":
                     tr.stats.sac.evla = geocentric_to_elliptic_latitude(
                         source.hypocenter_latitude
                     )
@@ -176,7 +186,7 @@ def _validate_and_write_waveforms(
                 src_lng = source.hypocenter_longitude
             else:
                 tr.stats.sac.evla = source.latitude
-                if sacheader == 'geodetic':
+                if sacheader == "geodetic":
                     tr.stats.sac.evla = geocentric_to_elliptic_latitude(
                         source.latitude
                     )
@@ -195,7 +205,7 @@ def _validate_and_write_waveforms(
 
             # For the Earth models, Sac coordinates are elliptical thus it
             # only makes sense to have elliptical distances.
-            if sacheader != 'geocentric':
+            if sacheader != "geocentric":
                 dist_in_m, az, baz = gps2dist_azimuth(
                     lat1=tr.stats.sac.evla,
                     lon1=tr.stats.sac.evlo,

--- a/instaseis/server/util.py
+++ b/instaseis/server/util.py
@@ -93,7 +93,7 @@ def _format_utc_datetime(dt):
 
 
 def _validate_and_write_waveforms(
-    st, starttime, endtime, scale, source, receiver, db, label, format
+    st, starttime, endtime, scale, source, receiver, db, label, format, sacheader='geodetic'
 ):
     if not label:
         label = ""
@@ -147,21 +147,26 @@ def _validate_and_write_waveforms(
         return binary_data, mu
     # Write a number of SAC files into an archive.
     elif format == "saczip":
+        assert sacheader in ("geodetic", "geocentric")
         byte_strings = []
         for tr in st:
             # Write SAC headers.
             tr.stats.sac = obspy.core.AttribDict()
-            # Write WGS84 coordinates to the SAC files.
-            tr.stats.sac.stla = geocentric_to_elliptic_latitude(
-                receiver.latitude
-            )
+            # Write WGS84 coordinates to the SAC files (for the Earth models only).
+            tr.stats.sac.stla = receiver.latitude
+            if sacheader == 'geodetic':
+                tr.stats.sac.stla = geocentric_to_elliptic_latitude(
+                    receiver.latitude
+                )
             tr.stats.sac.stlo = receiver.longitude
             tr.stats.sac.stdp = receiver.depth_in_m
             tr.stats.sac.stel = 0.0
             if isinstance(source, FiniteSource):
-                tr.stats.sac.evla = geocentric_to_elliptic_latitude(
-                    source.hypocenter_latitude
-                )
+                tr.stats.sac.evla = source.hypocenter_latitude
+                if sacheader == 'geodetic':
+                    tr.stats.sac.evla = geocentric_to_elliptic_latitude(
+                        source.hypocenter_latitude
+                    )
                 tr.stats.sac.evlo = source.hypocenter_longitude
                 tr.stats.sac.evdp = source.hypocenter_depth_in_m
                 # Force source has no magnitude.
@@ -170,9 +175,11 @@ def _validate_and_write_waveforms(
                 src_lat = source.hypocenter_latitude
                 src_lng = source.hypocenter_longitude
             else:
-                tr.stats.sac.evla = geocentric_to_elliptic_latitude(
-                    source.latitude
-                )
+                tr.stats.sac.evla = source.latitude
+                if sacheader == 'geodetic':
+                    tr.stats.sac.evla = geocentric_to_elliptic_latitude(
+                        source.latitude
+                    )
                 tr.stats.sac.evlo = source.longitude
                 tr.stats.sac.evdp = source.depth_in_m
                 # Force source has no magnitude.
@@ -186,15 +193,24 @@ def _validate_and_write_waveforms(
             # just assume to be the starttime here?
             tr.stats.sac.o = source.origin_time - starttime
 
-            # Sac coordinates are elliptical thus it only makes sense to
-            # have elliptical distances.
-            dist_in_m, az, baz = gps2dist_azimuth(
-                lat1=tr.stats.sac.evla,
-                lon1=tr.stats.sac.evlo,
-                lat2=tr.stats.sac.stla,
-                lon2=tr.stats.sac.stlo,
-            )
-
+            # For the Earth models, Sac coordinates are elliptical thus it
+            # only makes sense to have elliptical distances.
+            if sacheader != 'geocentric':
+                dist_in_m, az, baz = gps2dist_azimuth(
+                    lat1=tr.stats.sac.evla,
+                    lon1=tr.stats.sac.evlo,
+                    lat2=tr.stats.sac.stla,
+                    lon2=tr.stats.sac.stlo,
+                )
+            else:
+                dist_in_m, az, baz = gps2dist_azimuth(
+                    lat1=tr.stats.sac.evla,
+                    lon1=tr.stats.sac.evlo,
+                    lat2=tr.stats.sac.stla,
+                    lon2=tr.stats.sac.stlo,
+                    a=float(db.info.planet_radius),
+                    f=0.0,
+                )
             tr.stats.sac.dist = dist_in_m / 1000.0
             tr.stats.sac.az = az
             tr.stats.sac.baz = baz

--- a/instaseis/source.py
+++ b/instaseis/source.py
@@ -135,7 +135,7 @@ def fault_vectors_lmn(strike, dip, rake):
     return l, m, n
 
 
-def strike_dip_rake_from_ln(l, n):
+def strike_dip_rake_from_ln(l, n):  # NOQA
     """
     compute strike, dip and rake from the fault vectors l and n
     describing the fault according to Udias Fig. 16.19

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -2569,10 +2569,7 @@ def test_output_sacheader(all_clients):
 
     # Other than the sac header, they should be identical!
     for tr in sac_st.traces + sac_st_geodetic.traces + sac_st_geocentric.traces:
-        try:
-            del tr.stats.sac
-        except KeyError:
-            pass
+        del tr.stats.sac
 
     # Now make sure the result is the same independent of the output format.
     assert sac_st == sac_st_geodetic == sac_st_geocentric

--- a/instaseis/tests/test_server.py
+++ b/instaseis/tests/test_server.py
@@ -2481,10 +2481,11 @@ def test_output_formats(all_clients):
 
 def test_output_sacheader(all_clients):
     """
-    The /seismograms route can return data as zip archive containing multiple SAC files. For sacheader=geocentric,
-    the SAC headers are populated using geocentric latitudes (input latitudes). For sacheader not defined or
-    sacheader=geodetic, the SAC header is populated using geodetic latitudes. Make sure the choice of sacheader
-    does not affect data.
+    The /seismograms route can return data as zip archive containing multiple
+    SAC files. For sacheader=geocentric, the SAC headers are populated using
+    geocentric latitudes (input latitudes). For sacheader not defined or
+    sacheader=geodetic, the SAC header is populated using geodetic latitudes.
+    Make sure the choice of sacheader does not affect data.
     """
     client = all_clients
 
@@ -2498,7 +2499,8 @@ def test_output_sacheader(all_clients):
         "sourcemomenttensor": "100000,100000,100000,100000,100000,100000",
     }
 
-    # First, no sacheader provided, saczip results in a folder of multiple sac files.
+    # First, no sacheader provided, saczip results in a folder of multiple sac
+    # files.
     params = copy.deepcopy(basic_parameters)
     request = fetch_sync(client, _assemble_url("seismograms", **params))
     # ObsPy needs the filename to be able to directly unpack zip files. We
@@ -2510,7 +2512,8 @@ def test_output_sacheader(all_clients):
     for tr in sac_st:
         assert tr.stats._format == "SAC"
 
-    # Second,  sacheader set to geodetic, saczip results in a folder of multiple sac files.
+    # Second,  sacheader set to geodetic, saczip results in a folder of
+    # multiple sac files.
     params = copy.deepcopy(basic_parameters)
     params["sacheader"] = "geodetic"
     request = fetch_sync(client, _assemble_url("seismograms", **params))
@@ -2523,7 +2526,8 @@ def test_output_sacheader(all_clients):
     for tr in sac_st_geodetic:
         assert tr.stats._format == "SAC"
 
-    # Third,  sacheader set to geocentric, saczip results in a folder of multiple sac files.
+    # Third,  sacheader set to geocentric, saczip results in a folder of
+    # multiple sac files.
     params = copy.deepcopy(basic_parameters)
     params["sacheader"] = "geocentric"
     request = fetch_sync(client, _assemble_url("seismograms", **params))
@@ -2551,24 +2555,38 @@ def test_output_sacheader(all_clients):
     assert sac_tr.stats.sac.stla == sac_tr_geodetic.stats.sac.stla
     assert sac_tr.stats.sac.evla == sac_tr_geodetic.stats.sac.evla
 
-    # The sacheader='geocentric' should be the same as the input parameter since not converted.
-    assert sac_tr_geocentric.stats.sac.stla == basic_parameters["receiverlatitude"]
-    assert sac_tr_geocentric.stats.sac.evla == basic_parameters["sourcelatitude"]
+    # The sacheader='geocentric' should be the same as the input parameter
+    # since not converted.
+    assert (
+        sac_tr_geocentric.stats.sac.stla
+        == basic_parameters["receiverlatitude"]
+    )
+    assert (
+        sac_tr_geocentric.stats.sac.evla == basic_parameters["sourcelatitude"]
+    )
 
     # Converting the geocentric latitude should result in ~geodetic latitude.
-    np.testing.assert_allclose(sac_tr_geodetic.stats.sac.stla, geocentric_to_elliptic_latitude(
-        sac_tr_geocentric.stats.sac.stla
-    ))
-    np.testing.assert_allclose(sac_tr_geodetic.stats.sac.evla, geocentric_to_elliptic_latitude(
-        sac_tr_geocentric.stats.sac.evla
-    ))
+    np.testing.assert_allclose(
+        sac_tr_geodetic.stats.sac.stla,
+        geocentric_to_elliptic_latitude(sac_tr_geocentric.stats.sac.stla),
+    )
+    np.testing.assert_allclose(
+        sac_tr_geodetic.stats.sac.evla,
+        geocentric_to_elliptic_latitude(sac_tr_geocentric.stats.sac.evla),
+    )
 
     # GCD should be the same.
-    np.testing.assert_allclose(sac_tr.stats.sac.gcarc, sac_tr_geodetic.stats.sac.gcarc)
-    np.testing.assert_allclose(sac_tr.stats.sac.gcarc, sac_tr_geocentric.stats.sac.gcarc)
+    np.testing.assert_allclose(
+        sac_tr.stats.sac.gcarc, sac_tr_geodetic.stats.sac.gcarc
+    )
+    np.testing.assert_allclose(
+        sac_tr.stats.sac.gcarc, sac_tr_geocentric.stats.sac.gcarc
+    )
 
     # Other than the sac header, they should be identical!
-    for tr in sac_st.traces + sac_st_geodetic.traces + sac_st_geocentric.traces:
+    for tr in (
+        sac_st.traces + sac_st_geodetic.traces + sac_st_geocentric.traces
+    ):
         del tr.stats.sac
 
     # Now make sure the result is the same independent of the output format.

--- a/instaseis/tests/tornado_testing_fixtures.py
+++ b/instaseis/tests/tornado_testing_fixtures.py
@@ -175,8 +175,7 @@ def get_travel_time(
 
 @pytest.fixture
 def io_loop(request):
-    """Create an instance of the `tornado.ioloop.IOLoop` for each test case.
-    """
+    """Create an instance of the `tornado.ioloop.IOLoop` for each test case."""
     io_loop = IOLoop()
     io_loop.make_current()
 


### PR DESCRIPTION
Instaseis now accepts "sacheader" parameter with the default value of "geodetic" and optional value of "geocentric" to control how an output SAC file header is populated. If the sacheader parameter is not provided or is set to "geodetic", there will be no change in the output SAC headers. However, if the parameter is set to "geocentric", the output SAC files header will be populated using geocentric coordinates. This option is intended as a support for the Mars models.